### PR TITLE
chore: :adhesive_bandage: comment out quartodoc sections in `_quarto.yml`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,20 +47,20 @@ website:
         - section: "Guide"
           href: docs/guide/index.qmd
 
-quartodoc:
-  sidebar: "docs/reference/_sidebar.yml"
-  style: "pkgdown"
-  dir: "docs/reference"
-  package: "seedcase_flower"
-  parser: google
-  dynamic: true
-  renderer:
-    style: _renderer.py
-    table_style: description-list
-    show_signature_annotations: true
+# quartodoc:
+#   sidebar: "docs/reference/_sidebar.yml"
+#   style: "pkgdown"
+#   dir: "docs/reference"
+#   package: "seedcase_flower"
+#   parser: google
+#   dynamic: true
+#   renderer:
+#     style: _renderer.py
+#     table_style: description-list
+#     show_signature_annotations: true
 
-metadata-files:
-  - docs/reference/_sidebar.yml
+# metadata-files:
+#   - docs/reference/_sidebar.yml
 
 format:
   seedcase-theme-html:


### PR DESCRIPTION
# Description

Since the reference docs doesn't exist yet, I think this is what breaks the formatting. At least, with these sections commented out, it works now for me locally 👌 

Related to [this comment](https://github.com/seedcase-project/seedcase-flower/pull/13/files#r2630657229) in #13 

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
