### PR TITLE
docs: 📝 add architecture page to design section

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -40,10 +40,10 @@ website:
         - CONTRIBUTING.md
     - id: design
       contents:
-        - text: "Design"
+        - section: "Design"
           href: docs/design/index.qmd
-        - text: "Architecture"
-          href: docs/design/architecture.qmd
+          contents:
+            - docs/design/architecture.qmd
     - id: guide
       contents:
         - section: "Guide"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -42,6 +42,8 @@ website:
       contents:
         - text: "Design"
           href: docs/design/index.qmd
+        - text: "Architecture"
+          href: docs/design/architecture.qmd
     - id: guide
       contents:
         - section: "Guide"


### PR DESCRIPTION
# Description

I noticed that the Architecture page was missing in the side navigation in the Design section, so I added it here. 

Needs a quick review.