### PR TITLE
docs: :pencil2: change a "properties" to "descriptor" under requirements

### DIFF
--- a/docs/design/index.qmd
+++ b/docs/design/index.qmd
@@ -29,7 +29,7 @@ Overall, Flower should:
 
 Specifically, Flower must:
 
--   Accept Data Package properties (i.e., the `datapackage.json` file)
+-   Accept a Data Package descriptor (i.e., the `datapackage.json` file)
     as input.
 -   Generate structured, human-readable documents from Data Package
     metadata.


### PR DESCRIPTION
# Description

Since we're talking about the `datapackage.json` file in the parenthesis, which we define as the "descriptor" on the architecture page.

Needs a quick review.

## Checklist

- [X] Formatted Markdown
