### PR TITLE
fix(ci): 🐛 re-add quartodoc section in Quarto config

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -49,20 +49,20 @@ website:
         - section: "Guide"
           href: docs/guide/index.qmd
 
-# quartodoc:
-#   sidebar: "docs/reference/_sidebar.yml"
-#   style: "pkgdown"
-#   dir: "docs/reference"
-#   package: "seedcase_flower"
-#   parser: google
-#   dynamic: true
-#   renderer:
-#     style: _renderer.py
-#     table_style: description-list
-#     show_signature_annotations: true
+quartodoc:
+  sidebar: "docs/reference/_sidebar.yml"
+  style: "pkgdown"
+  dir: "docs/reference"
+  package: "seedcase_flower"
+  parser: google
+  dynamic: true
+  renderer:
+    style: _renderer.py
+    table_style: description-list
+    show_signature_annotations: true
 
-# metadata-files:
-#   - docs/reference/_sidebar.yml
+metadata-files:
+  - docs/reference/_sidebar.yml
 
 format:
   seedcase-theme-html:

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ build-website:
   # Delete any previously built files from quartodoc.
   # -f is to not give an error if the files don't exist yet.
   rm -rf docs/reference
-  # uv run quartodoc build
+  uv run quartodoc build
   uv run quarto render --execute
 
 # Check the commit messages on the current branch that are not on the main branch


### PR DESCRIPTION
# Description

The build-website action fails currently because this is missing. I initially commented it out bc of formatting issues (#15), however, the build-website action has failed since then.

For me, running the `just build-website` recipe locally made the formatting work again in other `qmd` files (when saving in Quarto's visual mode). Let me know if that fixes it for you too, so we can - hopefully - add this section again now 🤞 

Needs a thorough review.