### PR TITLE
chore: :wrench: Remove reports that cause empty test to fail

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # - If tests fail, do not generate coverage report
 # - Create the coverage report in XML (for badge), terminal, and HTML
 # - Trigger failure if below 90% code coverage
-addopts = --tb=short --import-mode=importlib --cov=src --no-cov-on-fail --cov-report=term --cov-report=xml --cov-report=html --cov-fail-under=90
+addopts = --tb=short --import-mode=importlib --cov=src --no-cov-on-fail --cov-report=term --cov-fail-under=90

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    pass


### PR DESCRIPTION
# Description

Deal with failing pytest when there are no tests, which I find quite annoying since all PRs in new repos become marked with :x:. 

It seems like [there is no way in pytest to pass when there are no tests](https://github.com/pytest-dev/pytest/issues/2393) (and good reasons not to). So the best seems to be to add a placeholder test.

It seems like the coverage is still failing even with the placeholder test (maybe because there are no lines of code to compare coverage with). This only happens when either the xml or html report is activated. Do we use these report for anything or can we safely remove them?

**Edit:** I can see that these are needed for some of the badges so maybe we have to find another way for this to work, maybe adding a placeholder function in the code too. It is also the genbadge package that throws another error in addition to what what thrown before by the xml/html reports, so this might require some more tweaking if we want it to run sucessfully

```
File "/home/joel/proj/seedcase/seedcase-flower/.venv/lib/python3.12/site-packages/genbadge/utils_coverage.py", line 178, in parse_root
    raise ValueError("Computed line rate (%s) is different from the one in the file (%s)"
ValueError: Computed line rate (0) is different from the one in the file (1.0)
```

A much simpler alternative to this is just to comment out the pytest in new repos, but it is important to remember to uncomment them again in that case and it could be hidden/forgotten easily in CI. I think the best approach might be to add a placeholder function with a corresponding test. That's easy to detect and remove manually when the first real test is added. 

Needs a thorough review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
