### PR TITLE
docs: :building_construction: add `verbose` and `output-dir` to CLI design

### DIFF
--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -226,7 +226,7 @@ well as prevent the unintended side effects that might arise when a
 style is mixed with incompatible configuration settings.
 
 This overriding behaviour also applies to the other CLI options,
-`--output-dir` and `--verbose`. If they are used on the CLI, they
+`--output-dir` and `--verbose`; if they are used on the CLI, they
 override the corresponding settings in the configuration file.
 
 ::: callout-important

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -117,6 +117,8 @@ flowchart LR
     config_file["_flower.toml or<br>pyproject.toml<br>[file]"]
     build("build")
     style_opt("--style<br>[option]")
+    verbose_opt("--verbose<br>[option]")
+    output_dir_opt("--output-dir<br>[option]")
     templates["Templates<br>[folder with<br>Jinja files]"]
     output["Output<br>[files and<br>folders]"]
     config{"config"}
@@ -125,6 +127,8 @@ flowchart LR
     templates --> config_file
     config_file -- "either" --> config
     style_opt -- "or" --> config
+    output_dir_opt --> config
+    verbose_opt --> build
     config --> build
     build --> output
 ```
@@ -220,6 +224,10 @@ style in the CLI rather than merging the CLI option with the config file
 settings. This will allow for quicker testing of different styles as
 well as prevent the unintended side effects that might arise when a
 style is mixed with incompatible configuration settings.
+
+This overriding behaviour also applies to the other CLI options,
+`--output-dir` and `--verbose`. If they are used on the CLI, they
+override the corresponding settings in the configuration file.
 
 ::: callout-important
 Flower does not check whether the `datapackage.json` file is correct or


### PR DESCRIPTION
# Description

This matches what was done in the `build()` design.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
