### PR TITLE
build: :pencil2: wrong file extension in `_quarto.yml`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -34,7 +34,7 @@ website:
       style: "floating"
       contents:
         - docs/index.qmd
-        - CHANGELOG.qmd
+        - CHANGELOG.md
         - CONTRIBUTING.md
     - id: design
       contents:


### PR DESCRIPTION
# Description

I put the wrong file extension in the `_quarto.yml` file.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
