### PR TITLE
docs: :pencil2: use relative path for `output-path`

### DIFF
--- a/docs/design/interface/config.qmd
+++ b/docs/design/interface/config.qmd
@@ -276,7 +276,7 @@ to complex. For example:
 # This creates an `index.qmd` containing the combined `package` and `contributors`
 # contents from the Jinja2 templates.
 [[section]]
-output-path = "docs/index.qmd"
+output-path = "index.qmd"
 [[section.contents]]
 jsonpath = "."
 template-path = "path/to/templates/package.qmd.jinja"
@@ -291,9 +291,9 @@ mode = "one"
 # This creates one file per resource in the `docs/resources/` folder.
 # E.g. `docs/resources/demographics.qmd`, `docs/resources/blood.qmd`, etc.
 [[section]]
-output-path = "docs/resources/"
+output-path = "resources/"
 # Or equivalently
-# output-path = "docs/resources/{resource-name}.qmd
+# output-path = "resources/{resource-name}.qmd
 [[section.contents]]
 jsonpath = ".resources"
 template-path = "path/to/templates/resources.qmd.jinja"
@@ -305,7 +305,7 @@ mode = "many"
 # In this example, this would allow you to use custom Quarto listings for the
 # fields: https://quarto.org/docs/websites/website-listings.html#yaml-listing-content
 [[section]]
-output-path = "docs/resources/{resource-name}/schema-fields.yml"
+output-path = "resources/{resource-name}/schema-fields.yml"
 [[section.contents]]
 jsonpath = ".resources[*].schema.fields"
 template-path = "path/to/templates/resource-schema-fields.yml.jinja"

--- a/docs/guide/custom-styles.qmd
+++ b/docs/guide/custom-styles.qmd
@@ -250,18 +250,18 @@ create:
 ``` {.toml filename="templates/sections.toml"}
 # One output file at docs/index.qmd
 [[section]]
-output-path = "docs/index.qmd"
+output-path = "index.qmd"
 
 # One output file for each resource in docs/resources/
 [[section]]
-output-path = "docs/resources/"
+output-path = "resources/"
 ```
 
 ::: callout-tip
 To generate more than one output file for a section, `output-path` can
-be set either to a folder (e.g., `docs/resources/`) or to a file path
+be set either to a folder (e.g., `resources/`) or to a file path
 with a placeholder for the file name (e.g.,
-`docs/resources/{resource-name}.qmd`). See the
+`resources/{resource-name}.qmd`). See the
 [`Section`](/docs/design/interface/config.qmd#section) documentation for
 more details.
 :::
@@ -290,7 +290,7 @@ Add content to each section, specifying the following fields:
 
 ``` {.toml filename="templates/sections.toml"}
 [[section]]
-output-path = "docs/index.qmd"
+output-path = "index.qmd"
 
 [[section.contents]]
 # Select the whole metadata object
@@ -312,7 +312,7 @@ jinja-variable = "contributors"
 mode = "one"
 
 [[section]]
-output-path = "docs/resources/"
+output-path = "resources/"
 
 [[section.contents]]
 jsonpath = "$.resources"

--- a/docs/guide/custom-styles.qmd
+++ b/docs/guide/custom-styles.qmd
@@ -259,11 +259,10 @@ output-path = "resources/"
 
 ::: callout-tip
 To generate more than one output file for a section, `output-path` can
-be set either to a folder (e.g., `resources/`) or to a file path
-with a placeholder for the file name (e.g.,
-`resources/{resource-name}.qmd`). See the
-[`Section`](/docs/design/interface/config.qmd#section) documentation for
-more details.
+be set either to a folder (e.g., `resources/`) or to a file path with a
+placeholder for the file name (e.g., `resources/{resource-name}.qmd`).
+See the [`Section`](/docs/design/interface/config.qmd#section)
+documentation for more details.
 :::
 
 #### Adding `[[section.contents]]`s

--- a/uv.lock
+++ b/uv.lock
@@ -615,11 +615,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.24.2"
+version = "3.24.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/a8/dae62680be63cbb3ff87cfa2f51cf766269514ea5488479d42fec5aa6f3a/filelock-3.24.2.tar.gz", hash = "sha256:c22803117490f156e59fafce621f0550a7a853e2bbf4f87f112b11d469b6c81b", size = 37601, upload-time = "2026-02-16T02:50:45.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/04/a94ebfb4eaaa08db56725a40de2887e95de4e8641b9e902c311bfa00aa39/filelock-3.24.2-py3-none-any.whl", hash = "sha256:667d7dc0b7d1e1064dd5f8f8e80bdac157a6482e8d2e02cd16fd3b6b33bd6556", size = 24152, upload-time = "2026-02-16T02:50:44Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
 ]
 
 [[package]]
@@ -2488,16 +2488,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.37.0"
+version = "20.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/03/a94d404ca09a89a7301a7008467aed525d4cdeb9186d262154dd23208709/virtualenv-20.38.0.tar.gz", hash = "sha256:94f39b1abaea5185bf7ea5a46702b56f1d0c9aa2f41a6c2b8b0af4ddc74c10a7", size = 5864558, upload-time = "2026-02-19T07:48:02.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/394801755d4c8684b655d35c665aea7836ec68320304f62ab3c94395b442/virtualenv-20.38.0-py3-none-any.whl", hash = "sha256:d6e78e5889de3a4742df2d3d44e779366325a90cf356f15621fddace82431794", size = 5837778, upload-time = "2026-02-19T07:47:59.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

This PR makes all `output-path`s in the documentation relative to `output-dir` (as they should be).


Needs a quick review.

## Checklist

- [x] Ran `just run-all`
