### PR TITLE
refactor: :recycle: extend and fix example `datapackage.json`

### DIFF
--- a/docs/includes/datapackage.json
+++ b/docs/includes/datapackage.json
@@ -5,28 +5,50 @@
   "description": "A dataset containing flora species records and their observed growth stages across different environments.",
   "version": "1.2.3",
   "created": "2025-11-07T11:12:56+01:00",
-  "keywords": ["flora", "species", "growth stages", "observations", "seasonal development"],
+  "keywords": [
+    "flora",
+    "species",
+    "growth stages",
+    "observations",
+    "seasonal development"
+  ],
   "licenses": [
     {
-        "name": "CCO 1.0 UNIVERSAL",
-        "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      "title": "CCO 1.0 UNIVERSAL",
+      "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+    },
+    {
+      "title": "Academic Free License 3.0",
+      "path": "https://opensource.org/licenses/AFL-3.0"
     }
   ],
   "contributors": [
     {
-      "title": "Jane Doe",
-      "role": ["creator"],
-      "email": "jane-doe@example.com",
+      "title": "Jane Dölitz",
+      "roles": [
+        "creator"
+      ],
+      "email": "jane-doelitz@example.com",
       "organization": "Example University"
     },
     {
       "title": "John Smith",
-      "role": ["author"],
+      "roles": [
+        "author",
+        "data collector"
+      ],
       "email": "john-smith@example.com",
       "organization": "Example Institute"
     }
   ],
-  "sources": [{ "title": "Example Data Source", "version": "1.0", "path": "https://example.com/data-source", "email": "source@example.com" }],
+  "sources": [
+    {
+      "title": "Example Data Source",
+      "version": "1.0",
+      "path": "https://example.com/data-source",
+      "email": "source@example.com"
+    }
+  ],
   "resources": [
     {
       "name": "species_catalog",
@@ -35,17 +57,103 @@
       "path": "resources/species_catalog/data.parquet",
       "format": "parquet",
       "encoding": "utf-8",
-      "primaryKey": "species_id",
       "schema": {
+        "primaryKey": "species_id",
+        "foreignKeys": [
+          {
+            "fields": [
+              "parent_species_id"
+            ],
+            "reference": {
+              "fields": [
+                "species_id"
+              ]
+            }
+          }
+        ],
         "fields": [
-          { "title": "Species ID", "name": "species_id", "type": "integer", "description": "The unique identifier for each species." },
-          { "title": "Scientific name", "name": "scientific_name", "type": "string", "description": "The Latin name of the species." },
-          { "title": "Common name", "name": "common_name", "type": "string", "description": "The common name of the species." },
-          { "title": "Family", "name": "family", "type": "string", "description": "The Latin family to which the species belongs." }
+          {
+            "title": "Species ID",
+            "name": "species_id",
+            "type": "integer",
+            "description": "The unique identifier for each species."
+          },
+          {
+            "title": "Scientific name",
+            "name": "scientific_name",
+            "type": "string",
+            "description": "The Latin name of the species."
+          },
+          {
+            "title": "Common name",
+            "name": "common_name",
+            "type": "string",
+            "description": "The common name of the species."
+          },
+          {
+            "title": "Family",
+            "name": "family",
+            "type": "string",
+            "description": "The Latin family to which the species belongs."
+          },
+          {
+            "title": "Parent Species",
+            "name": "parent_species_id",
+            "type": "integer",
+            "description": "The parent species of this species."
+          }
         ]
       },
       "sources": [
-        { "title": "Flora Species Source", "version": "1.0", "path": "https://example.com/data-source/flora-species", "email": "source@example.com" }]
+        {
+          "title": "Flora Species Source",
+          "version": "1.0",
+          "path": "https://example.com/data-source/flora-species",
+          "email": "source@example.com"
+        }
+      ]
+    },
+    {
+      "name": "location_catalog",
+      "title": "Flora Species Locations",
+      "description": "This resource contains a catalog of flora species locations.",
+      "path": "resources/location_catalog/data.parquet",
+      "format": "parquet",
+      "encoding": "utf-8",
+      "schema": {
+        "primaryKey": [
+          "region",
+          "country"
+        ],
+        "fields": [
+          {
+            "title": "Region",
+            "name": "region",
+            "type": "string",
+            "description": "The region the location is in."
+          },
+          {
+            "title": "Country",
+            "name": "country",
+            "type": "string",
+            "description": "The country the location is in."
+          },
+          {
+            "title": "Local Name",
+            "name": "local_name",
+            "type": "string",
+            "description": "The name of the location in the local language."
+          }
+        ]
+      },
+      "sources": [
+        {
+          "title": "Flora Species Locations Source",
+          "version": "1.0",
+          "path": "https://example.com/data-source/locations",
+          "email": "source@example.com"
+        }
+      ]
     },
     {
       "name": "growth_records",
@@ -54,21 +162,69 @@
       "path": "resources/growth_records/data.parquet",
       "format": "parquet",
       "encoding": "utf-8",
-      "primaryKey": "record_id",
-      "foreignKey": {
-          "fields": "species_id",
-          "reference": {
-            "resource": "species_catalog",
-            "fields": "species_id"
-          }
-        },
       "schema": {
+        "primaryKey": [
+          "record_id"
+        ],
+        "foreignKeys": [
+          {
+            "fields": "species_id",
+            "reference": {
+              "resource": "species_catalog",
+              "fields": "species_id"
+            }
+          },
+          {
+            "fields": [
+              "location_region",
+              "location_country"
+            ],
+            "reference": {
+              "resource": "location_catalog",
+              "fields": [
+                "region",
+                "country"
+              ]
+            }
+          }
+        ],
         "fields": [
-          { "title": "Record ID", "name": "record_id", "type": "integer", "description": "The unique identifier for each growth record." },
-          { "title": "Species ID", "name": "species_id", "type": "integer", "description": "The unique identifier for each species." },
-          { "title": "Observation date", "name": "observation_date", "type": "date", "description": "The date when the observation was made." },
-          { "title": "Growth Stage", "name": "growth_stage", "type": "string", "description": "The observed growth stage of the species." },
-          { "title": "Location", "name": "location", "type": "string", "description": "The location where the observation was made." }
+          {
+            "title": "Record ID",
+            "name": "record_id",
+            "type": "integer",
+            "description": "The unique identifier for each growth record."
+          },
+          {
+            "title": "Species",
+            "name": "species_id",
+            "type": "integer",
+            "description": "The species the observation was made for."
+          },
+          {
+            "title": "Observation date",
+            "name": "observation_date",
+            "type": "date",
+            "description": "The date when the observation was made."
+          },
+          {
+            "title": "Growth Stage",
+            "name": "growth_stage",
+            "type": "string",
+            "description": "The observed growth stage of the species."
+          },
+          {
+            "title": "Location Region",
+            "name": "location_region",
+            "type": "string",
+            "description": "The region of the location."
+          },
+          {
+            "title": "Location Country",
+            "name": "location_country",
+            "type": "string",
+            "description": "The country of the location."
+          }
         ]
       }
     }


### PR DESCRIPTION
# Description

This PR fixes some mistakes in the example `datapackage.json` and also adds some more properties that are useful for testing templates.


Needs a quick review.

## Checklist

- [x] Ran `just run-all`
