### PR TITLE
feat: :sparkles: add `quarto-one-page` style

### DIFF
--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -1,28 +1,24 @@
-# {{ package.name | _inline_code }}: {{ package.description }}
+# {{ package.name | _inline_code }}: {{ package.title }}
 
-**Licenses:** {% for license in package.licenses -%}
-[{{ license.title or license.name }}]({{ license.path }})
-{%- if not loop.last %}, {% endif -%}
+**Licenses:**
+
+{% for license in package.licenses -%}
+- [{{ license.title or license.name }}]({{ license.path }})
 {% endfor %}
-
 **Version:** {{ package.version }}
-
-**ID:** {{ package.id }}
 
 {{ package.description }}
 
 ## Contributors
 
 {% for contributor in package.contributors -%}
-- {{ contributor.title }}: {{ contributor.roles | join(', ') }}
-
-  <{{ contributor.email }}>
+- {{ contributor.title }} (<{{ contributor.email }}>): {{ contributor.roles | join(', ') }}
 {% endfor %}
 
 ## Resources
 
 {% for resource in package.resources -%}
-### {{ resource.title }} ({{ resource.name | _inline_code }})
+### {{ resource.name | _inline_code }}: {{ resource.title }}
 
 {{ resource.description }}
 

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -1,0 +1,52 @@
+# {{ package.name | _inline_code }}: {{ package.description }}
+
+**Licenses:** {% for license in package.licenses -%}
+[{{ license.title or license.name }}]({{ license.path }})
+{%- if not loop.last %}, {% endif -%}
+{% endfor %}
+
+**Version:** {{ package.version }}
+
+**ID:** {{ package.id }}
+
+{{ package.description }}
+
+## Contributors
+
+{% for contributor in package.contributors -%}
+- {{ contributor.title }}: {{ contributor.roles | join(', ') }}
+
+  <{{ contributor.email }}>
+{% endfor %}
+
+## Resources
+
+{% for resource in package.resources -%}
+### {{ resource.title }} ({{ resource.name | _inline_code }})
+
+{{ resource.description }}
+
+- Path: {{ resource.path | _inline_code }}
+- Primary key: ({{ resource.schema.primaryKey | _inline_code_list }})
+{% if resource.schema.foreignKeys -%}
+- Foreign keys:
+{% for fk in resource.schema.foreignKeys %}
+  - From fields ({{
+        fk.fields | _inline_code_list
+    }}) to fields ({{
+        fk.reference.fields | _inline_code_list
+    }}) in resource {{
+      (fk.reference.resource or resource.name)
+      | _inline_code
+    }}
+{%- endfor %}
+{%- endif %}
+
+| Title | Name | Type | Description |
+|-------|------|------|-------------|
+{% for field in resource.schema.fields -%}
+| {{ field.title }} | {{ field.name | _inline_code}} | {{ field.type }} | {{ field.description }} |
+{% endfor %}
+: Fields in the {{ resource.name | _inline_code }} resource.
+
+{% endfor %}

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -1,33 +1,61 @@
-# {{ package.name | _inline_code }}: {{ package.title }}
+{% if package.name or package.title %}
+# {{ (package.name | _inline_code) or package.title }}{{ ": " ~ package.title if package.name }}
+{% endif %}
+{% if package.licenses %}
 
 **Licenses:**
 
-{% for license in package.licenses -%}
-- [{{ license.title or license.name }}]({{ license.path }})
+{% for license in package.licenses %}
+{% if license.path %}
+-   [{{ license.title or license.name or "License" }}]({{ license.path }})
+{% else %}
+-   {{ license.title or license.name }}
+{% endif %}
 {% endfor %}
+{% endif %}
+{% if package.version %}
+
 **Version:** {{ package.version }}
+{% endif %}
+{% if package.description %}
 
 {{ package.description }}
+{% endif %}
+{% if package.contributors %}
 
 ## Contributors
 
-{% for contributor in package.contributors -%}
-- {{ contributor.title }} (<{{ contributor.email }}>): {{ contributor.roles | join(', ') }}
+{% for contributor in package.contributors %}
+{% set label = contributor.title or (contributor.firstName ~ " " ~ contributor.lastName) | trim or contributor.organization %}
+{% set email = "<" ~ contributor.email ~ ">" if contributor.email %}
+{% set roles = contributor.roles | join(', ') %}
+{% if label or email %}
+-   {{ label or email }}{{ " (" ~ email ~ ")" if label and email }}{{ ": " ~ roles if roles }}
+{% endif %}
 {% endfor %}
+{% endif %}
 
 ## Resources
+{% for resource in package.resources %}
 
-{% for resource in package.resources -%}
-### {{ resource.name | _inline_code }}: {{ resource.title }}
+### {{ resource.name | _inline_code }}{{ ": " ~ resource.title if resource.title }}
+{% if resource.description %}
 
 {{ resource.description }}
+{% endif %}
+{% if resource.path %}
 
-- Path: {{ resource.path | _inline_code }}
-- Primary key: ({{ resource.schema.primaryKey | _inline_code_list }})
-{% if resource.schema.foreignKeys -%}
-- Foreign keys:
-{% for fk in resource.schema.foreignKeys %}
-  - From fields ({{
+-   Path: {{ resource.path | _inline_code }}
+{% endif %}
+{% if resource.schema %}
+{% set schema = resource.schema %}
+{% if schema.primaryKey %}
+-   Primary key: ({{ schema.primaryKey | _inline_code_list }})
+{% endif %}
+{% if schema.foreignKeys %}
+-   Foreign keys:
+{% for fk in schema.foreignKeys %}
+    -   From fields ({{
         fk.fields | _inline_code_list
     }}) to fields ({{
         fk.reference.fields | _inline_code_list
@@ -35,14 +63,15 @@
       (fk.reference.resource or resource.name)
       | _inline_code
     }}
-{%- endfor %}
-{%- endif %}
+{% endfor %}
+{% endif %}
 
 | Title | Name | Type | Description |
 |-------|------|------|-------------|
-{% for field in resource.schema.fields -%}
-| {{ field.title }} | {{ field.name | _inline_code}} | {{ field.type }} | {{ field.description }} |
+{% for field in schema.fields %}
+| {{ field.title or "N/A" }} | {{ field.name | _inline_code}} | {{ field.type or "any" }} | {{ field.description or "N/A" }} |
 {% endfor %}
-: Fields in the {{ resource.name | _inline_code }} resource.
 
+: Fields in the {{ resource.name | _inline_code }} resource.
+{% endif %}
 {% endfor %}

--- a/src/seedcase_flower/styles/quarto_one_page/sections.toml
+++ b/src/seedcase_flower/styles/quarto_one_page/sections.toml
@@ -1,0 +1,8 @@
+[[section]]
+output-path = "index.qmd"
+
+[[section.contents]]
+jsonpath = "$"
+template-path = "package.qmd.jinja"
+jinja-variable = "package"
+mode = "one"


### PR DESCRIPTION
# Description

This PR adds the `quarto-one-page` style.

One thing to improve is the handling of missing data: what if a license has no URL, a contributor no title, etc., but for ALL fields used in the template.
I'm very happy to come up with a nicer way of dealing with this than just if-else statements around every line, but I wanted to get some feedback first on how exactly we want it to be.

[Here's](https://github.com/seedcase-project/seedcase-flower/blob/test/demo-using-quarto-one-page/demo-docs/index.qmd) the markdown generated from the template by running `uv run seedcase-flower build --uri docs/includes/datapackage.json --output-dir demo-docs` (using some quick and dirty code I added on that branch). If you check that out or copy the file, you can render the markdown (the page is too long to include as an image). 

Closes #91 

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
