### PR TITLE
docs: :building_construction: match design with how cyclopts handles config

### DIFF
--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -233,43 +233,38 @@ Python package that represents the CLI.
 ```{mermaid}
 %%| label: fig-c4-component
 %%| fig-cap: "C4 component diagram showing the parts of the Python package that contribute to the CLI and their connections."
-flowchart
-
-    subgraph python_package["Python code"]
-
-        subgraph config_file["Configuration"]
+flowchart TB
+    subgraph package["Python code"]
+        subgraph cfg["Configuration"]
             config("Config<br>[class]")
             section("Section<br>[class]")
         end
 
-        load_config["load_config()<br>[function]"]
         read_properties["read_properties()<br>[function]"]
         properties["properties<br>[dict]"]
         build("build()<br>[function]")
         view("view()<br>[function]")
 
-        config_file -- "Sets build<br>configurations<br>from file" --> load_config
-
         read_properties --> properties
         properties --> build & view
-        load_config -- "Adds build<br>configurations" --> build & view
+        cfg --> build & view
     end
 
-    templates("Templates<br>[folder with<br>Jinja files]")
     user("User<br>[person]")
+    templates("Templates<br>[folder with<br>Jinja files]")
     output_files("Output<br>[files and<br>folders]")
-    output_screen("Output<br>[text in the Terminal]")
+    output_screen("Output<br>[text in the<br>Terminal]")
 
-    templates --"Sets output<br>structure and layout"--> section
     user --"Gives<br>datapackage.json"--> read_properties
-    user --"Gives configurations,<br>as file, Python classes,<br>or from CLI<br>(optional)"--> config_file
     user --"Gives templates<br>in folder<br>(optional)"--> templates
+    user --"Gives configurations,<br>as file, Python classes,<br>or from CLI<br>(optional)"--> config
+    templates --"Sets output<br>structure and layout"--> section
     build --"Populates template(s)<br>with metadata items"--> output_files
     view --"Displays output<br>to screen"--> output_screen
 
     %% Styling
-    style python_package fill:#FFFFFF, color:#000000
-    style config_file fill:#FFFFFF, color:#000000, stroke-dasharray: 5 5
+    style package fill:#FFFFFF, color:#000000
+    style cfg fill:#FFFFFF, color:#000000, stroke-dasharray: 5 5
 ```
 
 For more details on the individual classes and functions, see the

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -15,7 +15,7 @@ has been finished and what remains to be done.
 `seedcase-flower` has the following signature:
 
 ``` {.bash filename="Terminal"}
-seedcase-flower <COMMAND> [OPTIONS] [ARGS]
+seedcase-flower <COMMAND> [PARAMETERS]
 ```
 
 When used on its own it will show the help message with available
@@ -51,59 +51,18 @@ There will be two commands available:
 - `view`: Display the `datapackage.json` metadata in a human-friendly
   way in the Terminal.
 
-::: {.callout-tip collapse="true" appearance="minimal"}
-### Pseudocode: CLI entry point
-
-This is the potential implementation of the CLI entry point in
-`src/seedcase_flower/cli.py`. This will be deleted once the CLI is
-implemented. We'll build the CLI using
-[Typer](https://typer.tiangolo.com/). Details on the interface as Python
-code for the individual CLI commands is found in the
-[Python interface](python.qmd) design document.
-
-``` {.python filename="src/seedcase_flower/cli.py"}
-import typer
-
-
-app = typer.Typer()
-
-
-@app.callback()
-def callback():
-    """Display your `datapackage.json` file in a human-friendly way."""
-
-@app.command()
-def build():
-    # See Python interface design doc.
-
-@app.command()
-def view():
-    # See Python interface design doc.
-```
-
-And the entry point for it in the `pyproject.toml` file would look like
-this:
-
-``` {.toml filename="pyproject.toml"}
-[project.scripts]
-seedcase-flower = "seedcase_flower.cli:app"
-```
-
-Which can be tested using `uv run seedcase-flower`.
-:::
-
 ## {{< var wip >}} `build`
 
-The `build` command has the following signature:
+The `build` command has the following signature, that is positional as well as keyword-based:
 
 ``` {.bash filename="Terminal"}
-seedcase-flower build [OPTIONS] [URI]
+seedcase-flower build [URI] [STYLE] [TEMPLATE-DIR] [OUTPUT-DIR] [VERBOSE]
 ```
 
-And when fully specified, it will look like this:
+And when used, it would look like this:
 
 ``` {.bash filename="Terminal"}
-seedcase-flower build --style STYLE URI
+seedcase-flower build URI --style STYLE
 ```
 
 The diagram below shows a simple flow for how the inputs and outputs
@@ -251,16 +210,16 @@ override the corresponding settings in the configuration file.
 
 ## {{< var planned >}} `view`
 
-The `view` command has the following base signature:
+The `view` command has the following signature, that is positional as well as keyword-based:
 
 ``` {.bash filename="Terminal"}
-seedcase-flower view [OPTIONS] [ARG]
+seedcase-flower view [URI] [STYLE]
 ```
 
-And when fully specified, it will look like this:
+And when used, it would look like this:
 
 ``` {.bash filename="Terminal"}
-seedcase-flower view --style STYLE URI
+seedcase-flower view URI --style STYLE
 ```
 
 The diagram below shows a simple flow for how the inputs and outputs

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -80,7 +80,7 @@ following parameters:
   as the default style is a built-in style that uses built-in templates.
   If given, `style` is ignored.
 - `output_dir` to specify where the root directory is for the output
-    files. Defaults to the current working directory.
+  files. Defaults to the current working directory.
 - `verbose` to output more messages, rather than have no output.
 
 The internal flow of this function is shown in the diagram below.
@@ -90,13 +90,13 @@ The internal flow of this function is shown in the diagram below.
 %%| fig-cap: "Diagram of the internal flow of functions and objects in the `build()` CLI function."
 flowchart TD
     uri:::input --> resolve_uri{{"resolve_uri()"}} --> path
-    path --> load_config{{"load_config()"}} --> Config
-    style_cfg[style]:::input --> load_config
-    template_dir_cfg[template_dir]:::input --> load_config
+    style_cfg[style]:::input --> Config
+    template_dir_cfg[template_dir]:::input --> Config
     path --> read_properties{{"read_properties()"}} --> properties
     properties & Config --> build_sections{{"build_sections()"}} --> output["list[BuiltSection]"]
     output --> write_sections{{"write_sections()"}}
-    output_dir:::input --> write_sections
+    output_dir:::input --> Config
+    Config --> write_sections
     write_sections --> files["list[Path]"]
     files --> cli_message{{"cli_message()"}} --> stdout
     verbose:::input --> cli_message


### PR DESCRIPTION
# Description

Since cyclopts loads the config for us, this updates that.

Closes #136

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
