### PR TITLE
test: :white_check_mark: mocking of basic app functionality

### DIFF
--- a/justfile
+++ b/justfile
@@ -137,6 +137,10 @@ build-readme:
 build-contributors:
     sh ./tools/get-contributors.sh seedcase-project/seedcase-flower > docs/includes/_contributors.qmd
 
+# Generate updated help-output strings for copy-pasting into test_cli.py
+generate-help-strings:
+    PYTHONPATH=. uv run python tools/generate-help-strings.py
+
 # Preview the documentation website with automatic reload on changes
 preview-website: build-quartodoc
     uv run quarto preview --execute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pre-commit>=4.5.0",
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
+    "pytest-mock>=3.14.0",
     "quartodoc>=0.11.1",
     "ruff>=0.14.7",
     "types-tabulate>=0.9.0.20241207",

--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -19,7 +19,7 @@ app = App(
         ),
         config.Toml(
             "pyproject.toml",
-            root_keys="tool.seedcase-flower",
+            root_keys=["tool", "seedcase-flower"],
             search_parents=True,
             use_commands_as_keys=False,
         ),

--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -9,6 +9,7 @@ from cyclopts import App, Parameter, config
 from seedcase_flower.internals import BuildStyle, _read_properties, _resolve_uri
 
 app = App(
+    name="seedcase-flower",
     help="Flower generates human-readable documentation from Data Packages.",
     default_parameter=Parameter(negative=()),
     config=[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,9 +98,7 @@ def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
     assert bound.arguments["verbose"] is True
 
 
-# ---------------------------------------------------------------------------
-# Help output
-# ---------------------------------------------------------------------------
+# === Help output ===
 
 
 @pytest.fixture
@@ -164,9 +162,7 @@ def test_build_help_page(capsys, console):
     )
 
 
-# ---------------------------------------------------------------------------
-# view (plain function, not an app command yet)
-# ---------------------------------------------------------------------------
+# === view (placeholder) ===
 
 
 def test_view() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def mock_read_properties(mocker):
     return mocker.patch("seedcase_flower.cli._read_properties")
 
 
-# === Testing CLI invocation ===
+# Testing CLI invocation ====
 
 
 def test_build_with_mocked_internals(mock_resolve_uri, mock_read_properties):
@@ -55,7 +55,7 @@ def test_build_with_mocked_internals(mock_resolve_uri, mock_read_properties):
     mock_read_properties.assert_called_once_with(fake_path)
 
 
-# === Checking stdout ===
+# Checking stdout ====
 
 
 # TODO: Update this when verbose is added.
@@ -75,7 +75,7 @@ def test_build_no_verbose_produces_no_output(capsys, datapackage_path):
     assert capsys.readouterr().out == ""
 
 
-# === File-based config ===
+# File-based config ====
 
 
 def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
@@ -99,7 +99,7 @@ def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
     assert bound.arguments["verbose"] is True
 
 
-# === Help output ===
+# Help output ====
 
 
 @pytest.fixture
@@ -163,7 +163,7 @@ def test_build_help_page(capsys, console):
     )
 
 
-# === view (placeholder) ===
+# view (placeholder) ====
 
 
 def test_view() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ def test_build_with_mocked_internals(mock_resolve_uri, mock_read_properties):
 # === Checking stdout ===
 
 
+# TODO: Update this when verbose is added.
 def test_build_verbose_prints_output(capsys, datapackage_path):
     """--verbose should print output_dir, properties, template_dir, and style."""
     app(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,7 @@ def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
 
 _HELP_PAGE = dedent(
     """\
-    Usge: seedcase-flower COMMAND
+    Usage: seedcase-flower COMMAND
 
     Flower generates human-readable documentation from Data Packages.
 
@@ -117,7 +117,7 @@ _HELP_PAGE = dedent(
 
 _BUILD_HELP_PAGE = dedent(
     """\
-    sage: seedcase-flower build [ARGS]
+    Usage: seedcase-flower build [ARGS]
 
     Build human-readable documentation from a datapackage.json file.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,50 +1,105 @@
-"""These are integration tests for the CLI commands."""
+"""Tests for the CLI commands."""
 
 import json
+from pathlib import Path
 
-from pytest import fixture, mark
+import pytest
 
-from seedcase_flower.cli import build, view
+from seedcase_flower.cli import app, view
 from seedcase_flower.internals import BuildStyle
 
+_DATAPACKAGE_DATA = {
+    "name": "placeholder",
+    "created": "2026-02-12T11:25:49+01:00",
+    "description": "Placeholder",
+    "id": "Placeholder",
+    "licenses": [{"name": "Placeholder"}],
+    "title": "Placeholder",
+    "version": "0.0.0",
+}
 
-# Create a file at tmp_path that is automatically cleaned up after tests finish
-@fixture
+
+@pytest.fixture
 def datapackage_path(tmp_path):
-    data = {
-        "name": "placeholder",
-        "created": "2026-02-12T11:25:49+01:00",
-        "description": "Placeholder",
-        "id": "Placeholder",
-        "licenses": [{"name": "Placeholder"}],
-        "title": "Placeholder",
-        "version": "0.0.0",
-    }
-
+    """Create a temporary datapackage.json and return its path as a string."""
     file_path = tmp_path / "datapackage.json"
-    file_path.write_text(json.dumps(data))
-
-    # Since `build` expects a str as the URI
+    file_path.write_text(json.dumps(_DATAPACKAGE_DATA))
     return str(file_path)
 
 
-@mark.parametrize(
-    "style, expected",
-    [
-        (BuildStyle.quarto_one_page, None),
-    ],
-)
-def test_build(
-    datapackage_path: str,
-    style: BuildStyle,
-    expected: None,
-) -> None:
-    """Test the build CLI function."""
-    result = build(datapackage_path, style=style)
-    assert result == expected
+@pytest.fixture
+def mock_resolve_uri(mocker):
+    """Mock _resolve_uri to isolate CLI tests from filesystem resolution."""
+    return mocker.patch("seedcase_flower.cli._resolve_uri")
+
+
+@pytest.fixture
+def mock_read_properties(mocker):
+    """Mock _read_properties to isolate CLI tests from file I/O."""
+    return mocker.patch("seedcase_flower.cli._read_properties")
+
+
+# === Testing CLI invocation ===
+
+
+def test_build_with_mocked_internals(mock_resolve_uri, mock_read_properties):
+    """Isolate CLI behaviour by mocking internal helpers."""
+    fake_path = Path("datapackage.json")
+    mock_resolve_uri.return_value = fake_path
+    # Simulate running the app from the command line (but without calling sys.exit())
+    app(["build", "datapackage.json"], result_action="return_value")
+
+    # Checking that the correct values were passed to the internal functions
+    mock_resolve_uri.assert_called_once_with("datapackage.json")
+    mock_read_properties.assert_called_once_with(fake_path)
+
+
+# === Checking stdout ===
+
+
+def test_build_verbose_prints_output(capsys, datapackage_path):
+    """--verbose should print output_dir, properties, template_dir, and style."""
+    app(
+        ["build", datapackage_path, "--verbose"],
+        result_action="return_value",
+    )
+    expected = f"docs {_DATAPACKAGE_DATA} None BuildStyle.quarto_one_page\n"
+    assert capsys.readouterr().out == expected
+
+
+def test_build_no_verbose_produces_no_output(capsys, datapackage_path):
+    """Without --verbose, build should produce no stdout."""
+    app(["build", datapackage_path], result_action="return_value")
+    assert capsys.readouterr().out == ""
+
+
+# === File-based config ===
+
+
+def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
+    """Build args specified in .flower.toml should overwrite the default values."""
+    toml_path = tmp_path / ".flower.toml"
+    toml_path.write_text(
+        'uri = "custom.json"\n'
+        'style = "quarto_resource_listing"\n'
+        'template_dir = "my-templates/"\n'
+        'output_dir = "my-docs/"\n'
+        "verbose = true\n"
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    _, bound, _ = app.parse_args(["build"])
+    assert bound.arguments["uri"] == "custom.json"
+    assert bound.arguments["style"] == BuildStyle.quarto_resource_listing
+    assert bound.arguments["template_dir"] == Path("my-templates/")
+    assert bound.arguments["output_dir"] == Path("my-docs/")
+    assert bound.arguments["verbose"] is True
+
+
+# TODO === view placeholder ===
 
 
 def test_view() -> None:
-    """Test the view CLI function."""
-    result = view()
-    assert result == ""
+    """view returns an empty string."""
+    assert view() == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,49 @@ def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
 
 # Help output ====
 
+_HELP_PAGE = dedent(
+    """\
+    Usge: seedcase-flower COMMAND
+
+    Flower generates human-readable documentation from Data Packages.
+
+    ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+    │ build        Build human-readable documentation from a datapackage.json file.          │
+    │ --help (-h)  Display this message and exit.                                            │
+    │ --version    Display application version.                                              │
+    ╰────────────────────────────────────────────────────────────────────────────────────────╯
+    """  # noqa
+)
+
+_BUILD_HELP_PAGE = dedent(
+    """\
+    sage: seedcase-flower build [ARGS]
+
+    Build human-readable documentation from a datapackage.json file.
+
+    ╭─ Parameters ───────────────────────────────────────────────────────────────────────────╮
+    │ URI --uri                    The URI to a datapackage.json file. [default:             │
+    │                              datapackage.json]                                         │
+    │ STYLE --style                The style used to structure the output. If a template     │
+    │                              directory is given, this parameter will be ignored.       │
+    │                              [choices: quarto-one-page, quarto-resource-listing,       │
+    │                              quarto-resource-tables] [default: quarto-one-page]        │
+    │ TEMPLATE-DIR --template-dir  The directory that contains the Jinja template files and  │
+    │                              sections.toml. When set, it will override any built-in    │
+    │                              style given by the style parameter.                       │
+    │ OUTPUT-DIR --output-dir      The directory to save the generated files in. [default:   │
+    │                              docs]                                                     │
+    │ VERBOSE --verbose            If True, prints additional information to the console.    │
+    │                              [default: False]                                          │
+    ╰────────────────────────────────────────────────────────────────────────────────────────╯
+    """  # noqa
+)
+
+_CHANGED_MSG = (
+    "The `{cmd}` help output changed. Run `just generate-help-strings` "
+    "and paste the updated string into the relevant test."
+)
+
 
 @pytest.fixture
 def console():
@@ -119,48 +162,14 @@ def test_help_page(capsys, console):
     """Top-level --help should match expected output."""
     with pytest.raises(SystemExit):
         app(["--help"], console=console)
-    assert capsys.readouterr().out == dedent(
-        """\
-        Usage: seedcase-flower COMMAND
-
-        Flower generates human-readable documentation from Data Packages.
-
-        ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-        │ build        Build human-readable documentation from a datapackage.json file.          │
-        │ --help (-h)  Display this message and exit.                                            │
-        │ --version    Display application version.                                              │
-        ╰────────────────────────────────────────────────────────────────────────────────────────╯
-        """  # noqa
-    )
+    assert capsys.readouterr().out == _HELP_PAGE, _CHANGED_MSG.format(cmd="general")
 
 
 def test_build_help_page(capsys, console):
     """build --help should document all parameters with defaults and choices."""
     with pytest.raises(SystemExit):
         app(["build", "--help"], console=console)
-    assert capsys.readouterr().out == dedent(
-        """\
-        Usage: seedcase-flower build [ARGS]
-
-        Build human-readable documentation from a datapackage.json file.
-
-        ╭─ Parameters ───────────────────────────────────────────────────────────────────────────╮
-        │ URI --uri                    The URI to a datapackage.json file. [default:             │
-        │                              datapackage.json]                                         │
-        │ STYLE --style                The style used to structure the output. If a template     │
-        │                              directory is given, this parameter will be ignored.       │
-        │                              [choices: quarto-one-page, quarto-resource-listing,       │
-        │                              quarto-resource-tables] [default: quarto-one-page]        │
-        │ TEMPLATE-DIR --template-dir  The directory that contains the Jinja template files and  │
-        │                              sections.toml. When set, it will override any built-in    │
-        │                              style given by the style parameter.                       │
-        │ OUTPUT-DIR --output-dir      The directory to save the generated files in. [default:   │
-        │                              docs]                                                     │
-        │ VERBOSE --verbose            If True, prints additional information to the console.    │
-        │                              [default: False]                                          │
-        ╰────────────────────────────────────────────────────────────────────────────────────────╯
-        """  # noqa
-    )
+    assert capsys.readouterr().out == _BUILD_HELP_PAGE, _CHANGED_MSG.format(cmd="build")
 
 
 # view (placeholder) ====

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -97,7 +98,75 @@ def test_build_reads_uri_from_flower_toml(tmp_path, monkeypatch):
     assert bound.arguments["verbose"] is True
 
 
-# TODO === view placeholder ===
+# ---------------------------------------------------------------------------
+# Help output
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def console():
+    from rich.console import Console
+
+    return Console(
+        width=90,
+        force_terminal=True,
+        highlight=False,
+        color_system=None,
+        legacy_windows=False,
+    )
+
+
+def test_help_page(capsys, console):
+    """Top-level --help should match expected output."""
+    with pytest.raises(SystemExit):
+        app(["--help"], console=console)
+    assert capsys.readouterr().out == dedent(
+        """\
+        Usage: seedcase-flower COMMAND
+
+        Flower generates human-readable documentation from Data Packages.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+        │ build        Build human-readable documentation from a datapackage.json file.          │
+        │ --help (-h)  Display this message and exit.                                            │
+        │ --version    Display application version.                                              │
+        ╰────────────────────────────────────────────────────────────────────────────────────────╯
+        """  # noqa
+    )
+
+
+def test_build_help_page(capsys, console):
+    """build --help should document all parameters with defaults and choices."""
+    with pytest.raises(SystemExit):
+        app(["build", "--help"], console=console)
+    assert capsys.readouterr().out == dedent(
+        """\
+        Usage: seedcase-flower build [ARGS]
+
+        Build human-readable documentation from a datapackage.json file.
+
+        ╭─ Parameters ───────────────────────────────────────────────────────────────────────────╮
+        │ URI --uri                    The URI to a datapackage.json file. [default:             │
+        │                              datapackage.json]                                         │
+        │ STYLE --style                The style used to structure the output. If a template     │
+        │                              directory is given, this parameter will be ignored.       │
+        │                              [choices: quarto-one-page, quarto-resource-listing,       │
+        │                              quarto-resource-tables] [default: quarto-one-page]        │
+        │ TEMPLATE-DIR --template-dir  The directory that contains the Jinja template files and  │
+        │                              sections.toml. When set, it will override any built-in    │
+        │                              style given by the style parameter.                       │
+        │ OUTPUT-DIR --output-dir      The directory to save the generated files in. [default:   │
+        │                              docs]                                                     │
+        │ VERBOSE --verbose            If True, prints additional information to the console.    │
+        │                              [default: False]                                          │
+        ╰────────────────────────────────────────────────────────────────────────────────────────╯
+        """  # noqa
+    )
+
+
+# ---------------------------------------------------------------------------
+# view (plain function, not an app command yet)
+# ---------------------------------------------------------------------------
 
 
 def test_view() -> None:

--- a/tools/generate-help-strings.py
+++ b/tools/generate-help-strings.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     if not changed:
         print("No changes detected. All help-output constants are up to date.")
     else:
-        print("\nReview that the ouput below looks as expected.")
+        print("\nReview that the output below looks as expected.")
         print("Then, copy and paste it into tests/test_cli.py,")
         print("replacing the variable(s) with the same name.")
         for name, args in changed:

--- a/tools/generate-help-strings.py
+++ b/tools/generate-help-strings.py
@@ -1,0 +1,69 @@
+"""Generate the expected help-output strings used in test_cli.py.
+
+Run this script after changing a docstring or CLI parameter. Only snippets
+whose output differs from the current constants in test_cli.py are printed,
+so you can copy-paste just the changed values back into that file.
+
+Usage:
+    just generate-help-strings
+"""
+
+import sys
+from io import StringIO
+
+from rich.console import Console
+
+from seedcase_flower.cli import app
+from tests.test_cli import _BUILD_HELP_PAGE, _HELP_PAGE
+
+
+def _capture_help(args: list[str]) -> str:
+    """Return the help text produced by *args* as a plain string."""
+    console = Console(
+        width=90,
+        force_terminal=True,
+        highlight=False,
+        color_system=None,
+        legacy_windows=False,
+    )
+
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            app(args, console=console)
+        except SystemExit:
+            pass
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+
+
+def _as_constant_snippet(name: str, text: str) -> str:
+    """Return a copy-pasteable constant assignment for *text*."""
+    lines = text.splitlines()
+    indented_body = "\n".join(f"    {line}" if line else "" for line in lines)
+    return f'{name} = dedent(\n    """\\\n{indented_body}\n    """  # noqa\n)'
+
+
+if __name__ == "__main__":
+    checks = [
+        ("_HELP_PAGE", ["--help"], _HELP_PAGE),
+        ("_BUILD_HELP_PAGE", ["build", "--help"], _BUILD_HELP_PAGE),
+    ]
+    changed = [
+        (name, args) for name, args, current in checks if _capture_help(args) != current
+    ]
+
+    if not changed:
+        print("No changes detected. All help-output constants are up to date.")
+    else:
+        print()
+        print("Review that the ouput below looks as expected.")
+        print("Then, copy and paste it into tests/test_cli.py,")
+        print("replacing the variable(s) with the same name.")
+        for name, args in changed:
+            print()
+            print()
+            print()
+            print(_as_constant_snippet(name, _capture_help(args)))

--- a/tools/generate-help-strings.py
+++ b/tools/generate-help-strings.py
@@ -6,6 +6,7 @@ whose output differs from the current constants in test_cli.py are printed.
 
 import sys
 from io import StringIO
+from operator import itemgetter
 
 from rich.console import Console
 
@@ -35,6 +36,19 @@ def _capture_help(args: list[str]) -> str:
         sys.stdout = old_stdout
 
 
+def _is_outdated(check: tuple[str, list[str], str]) -> bool:
+    """Return True if the current help output differs from the stored constant."""
+    _, args, current = check
+    return _capture_help(args) != current
+
+
+def _find_outdated_checks(
+    checks: list[tuple[str, list[str], str]],
+) -> list[tuple[str, list[str]]]:
+    """Return checks whose current help output differs from the stored constant."""
+    return list(map(itemgetter(0, 1), filter(_is_outdated, checks)))
+
+
 def _as_constant_snippet(name: str, text: str) -> str:
     """Return a copy-pasteable constant assignment for *text*."""
     lines = text.splitlines()
@@ -47,9 +61,7 @@ if __name__ == "__main__":
         ("_HELP_PAGE", ["--help"], _HELP_PAGE),
         ("_BUILD_HELP_PAGE", ["build", "--help"], _BUILD_HELP_PAGE),
     ]
-    changed = [
-        (name, args) for name, args, current in checks if _capture_help(args) != current
-    ]
+    changed = _find_outdated_checks(checks)
 
     if not changed:
         print("No changes detected. All help-output constants are up to date.")

--- a/tools/generate-help-strings.py
+++ b/tools/generate-help-strings.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         print("No changes detected. All help-output constants are up to date.")
     else:
         print()
-        print("Review that the ouput below looks as expected.")
+        print("Review that the output below looks as expected.")
         print("Then, copy and paste it into tests/test_cli.py,")
         print("replacing the variable(s) with the same name.")
         for name, args in changed:

--- a/tools/generate-help-strings.py
+++ b/tools/generate-help-strings.py
@@ -1,11 +1,7 @@
 """Generate the expected help-output strings used in test_cli.py.
 
 Run this script after changing a docstring or CLI parameter. Only snippets
-whose output differs from the current constants in test_cli.py are printed,
-so you can copy-paste just the changed values back into that file.
-
-Usage:
-    just generate-help-strings
+whose output differs from the current constants in test_cli.py are printed.
 """
 
 import sys
@@ -58,12 +54,9 @@ if __name__ == "__main__":
     if not changed:
         print("No changes detected. All help-output constants are up to date.")
     else:
-        print()
-        print("Review that the output below looks as expected.")
+        print("\nReview that the ouput below looks as expected.")
         print("Then, copy and paste it into tests/test_cli.py,")
         print("replacing the variable(s) with the same name.")
         for name, args in changed:
-            print()
-            print()
-            print()
+            print("\n\n")
             print(_as_constant_snippet(name, _capture_help(args)))

--- a/uv.lock
+++ b/uv.lock
@@ -1842,6 +1842,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
+]
+
+[[package]]
 name = "python-json-logger"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2202,27 +2215,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.2"
+version = "0.15.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3b/20d9a0bc954d51b63f20cf710cf506bfe675d1e6138139342dd5ccc90326/ruff-0.15.3.tar.gz", hash = "sha256:78757853320d8ddb9da24e614ef69a37bcbcfd477e5a6435681188d4bce4eaa1", size = 4569031, upload-time = "2026-02-26T15:39:38.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
-    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
-    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
-    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
-    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/c544ab1d70f86dc50a2f2a8e1262e5af5025897ccd820415f559f9f2f63f/ruff-0.15.3-py3-none-linux_armv6l.whl", hash = "sha256:f7df0fd6f889a8d8de2ddb48a9eb55150954400f2157ea15b21a2f49ecaaf988", size = 10444066, upload-time = "2026-02-26T15:39:47.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/15/9dee3f4e891261adbd690f8c6f075418a7cd76e845601b00a0da2ae2ad6e/ruff-0.15.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0198b5445197d443c3bbf2cc358f4bd477fb3951e3c7f2babc13e9bb490614a8", size = 10853125, upload-time = "2026-02-26T15:40:18.943Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ba/fc5aeda852c89faf821d36c951df866117342e88439e1b1e1e762a07b7fd/ruff-0.15.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:adf95b5be57b25fbbbc07cd68d37414bee8729e807ad0217219558027186967e", size = 10180833, upload-time = "2026-02-26T15:40:13.282Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/e2f80a39164476fac4d45752a0d4721d6645f40b7f851e48add12af9947e/ruff-0.15.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b56dbd9cd86489ccbad96bb58fa4c958342b5510fdeb60ea13d9d3566bd845c", size = 10536806, upload-time = "2026-02-26T15:40:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/89/2e5bf0ed30ea3778460ea4d8cc6cb4d88ba96d9732d2c0cc33349cd65196/ruff-0.15.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6f263ce511871955d8c5401b62c7e863988ea4d0527aa0a3b1b7ecff4d4abc4", size = 10276093, upload-time = "2026-02-26T15:39:44.654Z" },
+    { url = "https://files.pythonhosted.org/packages/82/cb/318206d778c7f42917ca7b0f9436cf27652d1731fe434d3c9990c4a611fa/ruff-0.15.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e90fa1bed82ffede5768232b9bd23212c547ab7cd74c752007ecade1d895ee1a", size = 11051593, upload-time = "2026-02-26T15:39:35.157Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8f/65ee4c1b88e49dd4c0a3fc43e81832536c7942f0c702b6f3d25db0f95d6c/ruff-0.15.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e9d53760b7061ddbe5ea9e25381332c607fc14c40bde78f8a25392a93a68d74", size = 11885820, upload-time = "2026-02-26T15:39:59.504Z" },
+    { url = "https://files.pythonhosted.org/packages/db/04/d4261f6729ad9a356bc6e3223ba297acf3b66118cef4795b4a8953b255ff/ruff-0.15.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ec90e3b78c56c4acca4264d371dd48e29215ecb673cc2fa3c4b799b72050e491", size = 11340583, upload-time = "2026-02-26T15:39:50.781Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/490f38b2bc104e0fdc9496c2a66a48fb2d24a01de46ba0c60c4f6c4d4590/ruff-0.15.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7ce448fd395f822e34c8f6f7dfcd84b6726340082950858f92c4daa6baf8915", size = 11160701, upload-time = "2026-02-26T15:40:02.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/25/eae9cb7b6c28b425ed8cbe797da89c78146071102181ba74c4cdfd06bbeb/ruff-0.15.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14f7d763962d385f75b9b3b57fcc5661c56c20d8b1ddc9f5c881b5fa0ba499fa", size = 11111482, upload-time = "2026-02-26T15:39:56.462Z" },
+    { url = "https://files.pythonhosted.org/packages/95/18/16d0b5ef143cb9e52724f18cbccb4b3c5cd4d4e2debbd95e2be3aeb64c9e/ruff-0.15.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b57084e3a3d65418d376c7023711c37cce023cd2fb038a76ba15ee21f3c2c2ee", size = 10497151, upload-time = "2026-02-26T15:40:10.64Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b4/1829314241ddba07c54a742ab387da343fe56a0267a6b6498f3e2ae99821/ruff-0.15.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d567523ff7dcf3112b0f71231d18c3506dd06943359476ee64dea0f9c8f63976", size = 10281955, upload-time = "2026-02-26T15:40:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/93/80a4ec4bd3cf58ca9b49dccf2bd232b520db14184912fb7e0eb6f3ecc484/ruff-0.15.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4223088d255bf31a50b6640445b39f668164d64c23e5fa403edfb1e0b11122e5", size = 10766613, upload-time = "2026-02-26T15:40:21.55Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/fe016b862295dc57499997e7f2edc58119469b210f4f03ccb763fa65f130/ruff-0.15.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:32399ddae088970b2db6efd8d3f49981375cb828075359b6c088ed1fe63d64e1", size = 11262113, upload-time = "2026-02-26T15:39:41.5Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b1/77dcd05940388d9ba3de03ac4b8b598826d57935728071e1be9f2ef5b714/ruff-0.15.3-py3-none-win32.whl", hash = "sha256:1f1eb95ff614351e3a89a862b6d94e6c42c170e61916e1f20facd6c38477f5f3", size = 10509423, upload-time = "2026-02-26T15:40:05.217Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d5/76aab0fabbd54e8c77d02fcff2494906ba85b539d22aa9b7124f7100f008/ruff-0.15.3-py3-none-win_amd64.whl", hash = "sha256:2b22dffe5f5e1e537097aa5208684f069e495f980379c4491b1cfb198a444d0c", size = 11637739, upload-time = "2026-02-26T15:39:53.951Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/61/9b4e3682dfd26054321e1b2fdb67a51361dd6ec2fb63f2b50d711f8832ae/ruff-0.15.3-py3-none-win_arm64.whl", hash = "sha256:82443c14d694d4cbd9e598ede27ef5d6f08389ccad91c933be775ea2f4e66f76", size = 10957794, upload-time = "2026-02-26T15:40:08.045Z" },
 ]
 
 [[package]]
@@ -2508,16 +2521,17 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.39.0"
+version = "21.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/54/809199edc537dbace273495ac0884d13df26436e910a5ed4d0ec0a69806b/virtualenv-20.39.0.tar.gz", hash = "sha256:a15f0cebd00d50074fd336a169d53422436a12dfe15149efec7072cfe817df8b", size = 5869141, upload-time = "2026-02-23T18:09:13.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/4f/d6a5ff3b020c801c808b14e2d2330cdc8ebefe1cdfbc457ecc368e971fec/virtualenv-21.0.0.tar.gz", hash = "sha256:e8efe4271b4a5efe7a4dce9d60a05fd11859406c0d6aa8464f4cf451bc132889", size = 5836591, upload-time = "2026-02-25T20:21:07.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/b4/8268da45f26f4fe84f6eae80a6ca1485ffb490a926afecff75fc48f61979/virtualenv-20.39.0-py3-none-any.whl", hash = "sha256:44888bba3775990a152ea1f73f8e5f566d49f11bbd1de61d426fd7732770043e", size = 5839121, upload-time = "2026-02-23T18:09:11.173Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d1/3f62e4f9577b28c352c11623a03fb916096d5c131303d4861b4914481b6b/virtualenv-21.0.0-py3-none-any.whl", hash = "sha256:d44e70637402c7f4b10f48491c02a6397a3a187152a70cba0b6bc7642d69fb05", size = 5817167, upload-time = "2026-02-25T20:21:05.476Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "bandit"
-version = "1.9.3"
+version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -148,9 +148,9 @@ dependencies = [
     { name = "rich" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/76/a7f3e639b78601118aaa4a394db2c66ae2597fbd8c39644c32874ed11e0c/bandit-1.9.3.tar.gz", hash = "sha256:ade4b9b7786f89ef6fc7344a52b34558caec5da74cb90373aed01de88472f774", size = 4242154, upload-time = "2026-01-19T04:05:22.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/0b/8bdc52111c83e2dc2f97403dc87c0830b8989d9ae45732b34b686326fb2c/bandit-1.9.3-py3-none-any.whl", hash = "sha256:4745917c88d2246def79748bde5e08b9d5e9b92f877863d43fab70cd8814ce6a", size = 134451, upload-time = "2026-01-19T04:05:20.938Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -226,11 +226,11 @@ css = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "commitizen"
-version = "4.13.8"
+version = "4.13.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -404,9 +404,9 @@ dependencies = [
     { name = "termcolor" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/8a/73c165b1c7b182f506208c959e0ac56c844eccdbbfc0fa4f23a2fa9aa6b7/commitizen-4.13.8.tar.gz", hash = "sha256:d8769c0b2ee7bfe15d6871af1e242913df696b4a94e91a8146c5d78b778144ee", size = 64155, upload-time = "2026-02-18T10:33:14.67Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/44/10f95e8178ab5a584298726a4a94ceb83a7f77e00741fec4680df05fedd5/commitizen-4.13.9.tar.gz", hash = "sha256:2b4567ed50555e10920e5bd804a6a4e2c42ec70bb74f14a83f2680fe9eaf9727", size = 64145, upload-time = "2026-02-25T02:40:05.326Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/13/204836f9c820c2f049bb0bdc385eb710f1755c96a5e37b7351f473d29ee0/commitizen-4.13.8-py3-none-any.whl", hash = "sha256:dfbe2b5cb074cd86398d88e7afabdc6ba530fc02377ed9a7510477efd8deff86", size = 85368, upload-time = "2026-02-18T10:33:13.595Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/9b14ee0f17f0aad219a2fb37a293a57b8324d9d195c6ef6807bcd0bf2055/commitizen-4.13.9-py3-none-any.whl", hash = "sha256:d2af3d6a83cacec9d5200e17768942c5de6266f93d932c955986c60c4285f2db", size = 85373, upload-time = "2026-02-25T02:40:03.83Z" },
 ]
 
 [[package]]
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.5.4"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -503,9 +503,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/d2/f37df900b163f51b4faacdb01bf4895c198906d67c5b2a85c2522de85459/cyclopts-4.5.4.tar.gz", hash = "sha256:eed4d6c76d4391aa796d8fcaabd50e5aad7793261792beb19285f62c5c456c8b", size = 162438, upload-time = "2026-02-20T00:58:46.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/5c/88a4068c660a096bbe87efc5b7c190080c9e86919c36ec5f092cb08d852f/cyclopts-4.6.0.tar.gz", hash = "sha256:483c4704b953ea6da742e8de15972f405d2e748d19a848a4d61595e8e5360ee5", size = 162724, upload-time = "2026-02-23T15:44:49.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/0f/119fa63fa93e0a331fbedcb27162d8f88d3ba2f38eba1567e3e44307b857/cyclopts-4.5.4-py3-none-any.whl", hash = "sha256:ad001986ec403ca1dc1ed20375c439d62ac796295ea32b451dfe25d6696bc71a", size = 200225, upload-time = "2026-02-20T00:58:47.275Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/1e8337755a70dc7d7ff10a73dc8f20e9352c9ad6c2256ed863ac95cd3539/cyclopts-4.6.0-py3-none-any.whl", hash = "sha256:0a891cb55bfd79a3cdce024db8987b33316aba11071e5258c21ac12a640ba9f2", size = 200518, upload-time = "2026-02-23T15:44:47.854Z" },
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.4"
+version = "4.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1087,9 +1087,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/6b/21af7c0512bdf67e0c54c121779a1f2a97a164a7657e13fced79db8fa5a0/jupyterlab-4.5.4.tar.gz", hash = "sha256:c215f48d8e4582bd2920ad61cc6a40d8ebfef7e5a517ae56b8a9413c9789fdfb", size = 23943597, upload-time = "2026-02-11T00:26:55.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/2d/953a5612a34a3c799a62566a548e711d103f631672fd49650e0f2de80870/jupyterlab-4.5.5.tar.gz", hash = "sha256:eac620698c59eb810e1729909be418d9373d18137cac66637141abba613b3fda", size = 23968441, upload-time = "2026-02-23T18:57:34.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/9f/a70972ece62ead2d81acc6223188f6d18a92f665ccce17796a0cdea4fcf5/jupyterlab-4.5.4-py3-none-any.whl", hash = "sha256:cc233f70539728534669fb0015331f2a3a87656207b3bb2d07916e9289192f12", size = 12391867, upload-time = "2026-02-11T00:26:51.23Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/52/372d3494766d690dfdd286871bf5f7fb9a6c61f7566ccaa7153a163dd1df/jupyterlab-4.5.5-py3-none-any.whl", hash = "sha256:a35694a40a8e7f2e82f387472af24e61b22adcce87b5a8ab97a5d9c486202a6d", size = 12446824, upload-time = "2026-02-23T18:57:30.398Z" },
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.3"
+version = "7.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
@@ -1428,9 +1428,9 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/cb/cc7f4df5cee315dd126a47eb60890690a0438d5e0dd40c32d60ce16de377/notebook-7.5.3.tar.gz", hash = "sha256:393ceb269cf9fdb02a3be607a57d7bd5c2c14604f1818a17dbeb38e04f98cbfa", size = 14073140, upload-time = "2026-01-26T07:28:36.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/08/9d446fbb49f95de316ea6d7f25d0a4bc95117dd574e35f405895ac706f29/notebook-7.5.4.tar.gz", hash = "sha256:b928b2ba22cb63aa83df2e0e76fe3697950a0c1c4a41b84ebccf1972b1bb5771", size = 14167892, upload-time = "2026-02-24T14:13:56.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/98/9286e7f35e5584ebb79f997f2fb0cb66745c86f6c5fccf15ba32aac5e908/notebook-7.5.3-py3-none-any.whl", hash = "sha256:c997bfa1a2a9eb58c9bbb7e77d50428befb1033dd6f02c482922e96851d67354", size = 14481744, upload-time = "2026-01-26T07:28:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/59/01/05e5387b53e0f549212d5eff58845886f3827617b5c9409c966ddc07cb6d/notebook-7.5.4-py3-none-any.whl", hash = "sha256:860e31782b3d3a25ca0819ff039f5cf77845d1bf30c78ef9528b88b25e0a9850", size = 14578014, upload-time = "2026-02-24T14:13:52.274Z" },
 ]
 
 [[package]]
@@ -2508,16 +2508,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.38.0"
+version = "20.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/03/a94d404ca09a89a7301a7008467aed525d4cdeb9186d262154dd23208709/virtualenv-20.38.0.tar.gz", hash = "sha256:94f39b1abaea5185bf7ea5a46702b56f1d0c9aa2f41a6c2b8b0af4ddc74c10a7", size = 5864558, upload-time = "2026-02-19T07:48:02.385Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/54/809199edc537dbace273495ac0884d13df26436e910a5ed4d0ec0a69806b/virtualenv-20.39.0.tar.gz", hash = "sha256:a15f0cebd00d50074fd336a169d53422436a12dfe15149efec7072cfe817df8b", size = 5869141, upload-time = "2026-02-23T18:09:13.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/394801755d4c8684b655d35c665aea7836ec68320304f62ab3c94395b442/virtualenv-20.38.0-py3-none-any.whl", hash = "sha256:d6e78e5889de3a4742df2d3d44e779366325a90cf356f15621fddace82431794", size = 5837778, upload-time = "2026-02-19T07:47:59.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b4/8268da45f26f4fe84f6eae80a6ca1485ffb490a926afecff75fc48f61979/virtualenv-20.39.0-py3-none-any.whl", hash = "sha256:44888bba3775990a152ea1f73f8e5f566d49f11bbd1de61d426fd7732770043e", size = 5839121, upload-time = "2026-02-23T18:09:11.173Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1818,6 +1818,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2233,6 +2245,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "quartodoc" },
     { name = "ruff" },
     { name = "types-tabulate" },
@@ -2257,6 +2270,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "quartodoc", specifier = ">=0.11.1" },
     { name = "ruff", specifier = ">=0.14.7" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },


### PR DESCRIPTION
This is a first implementation of the tests we can use to check that the CLI is behaving correctly. I think this covers most of what we currently have in main, at least we reach :100: % coverage!

Merging this before some of the existing PRs e.g. #140 and #152 will make it easier to add new tests specifically for the functionality added there instead of convoluting it with testing the general functionality of the app which is tested here instead.

I tried to follow the cyclopts test docs as closely as possible, but let me know if you think something is missing. I also experimented with using the Copilot CLI for the first time to help me get started and understanding how to write the tests. It was quite useful, particularly to get started, but I did have to delete about half of its suggestions because there was a lot of redundancy. Thought I would mention it in case someone catches something odd in here so I can blame it and not me =p

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
