### PR TITLE
chore: :wrench: reformat as per just run all

### DIFF
--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -53,7 +53,8 @@ There will be two commands available:
 
 ## {{< var wip >}} `build`
 
-The `build` command has the following signature, that is positional as well as keyword-based:
+The `build` command has the following signature, that is positional as
+well as keyword-based:
 
 ``` {.bash filename="Terminal"}
 seedcase-flower build [URI] [STYLE] [TEMPLATE-DIR] [OUTPUT-DIR] [VERBOSE]
@@ -210,7 +211,8 @@ override the corresponding settings in the configuration file.
 
 ## {{< var planned >}} `view`
 
-The `view` command has the following signature, that is positional as well as keyword-based:
+The `view` command has the following signature, that is positional as
+well as keyword-based:
 
 ``` {.bash filename="Terminal"}
 seedcase-flower view [URI] [STYLE]

--- a/docs/includes/_contributors.qmd
+++ b/docs/includes/_contributors.qmd
@@ -1,3 +1,3 @@
 The following people have contributed to this project by submitting pull requests :tada:
 
- [\@lwjohnst86](https://github.com/lwjohnst86), [\@signekb](https://github.com/signekb), [\@joelostblom](https://github.com/joelostblom), [\@martonvago](https://github.com/martonvago)
+ [\@lwjohnst86](https://github.com/lwjohnst86), [\@joelostblom](https://github.com/joelostblom), [\@signekb](https://github.com/signekb), [\@martonvago](https://github.com/martonvago)


### PR DESCRIPTION
# Description

I see this come up every time I run through the just checks in other PRs

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
