### PR TITLE
refactor: :recycle: move `parse_source()` into own file

### DIFF
--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -12,11 +12,10 @@ from rich.theme import Theme
 
 from seedcase_flower.config import Config
 from seedcase_flower.internals import (
-    Address,
     _build_sections,
     _format_param_help,
-    _parse_source,
 )
+from seedcase_flower.parse_source import Address, parse_source
 from seedcase_flower.read_properties import read_properties
 from seedcase_flower.styles import Style, ViewStyle
 from seedcase_flower.write_sections import write_sections
@@ -94,7 +93,7 @@ def build(
         template_dir=template_dir,
         output_dir=output_dir,
     )
-    address: Address = _parse_source(source)
+    address: Address = parse_source(source)
     properties: dict[str, Any] = read_properties(address)
     built_sections = _build_sections(properties, config)
     output_files: list[Path] = write_sections(built_sections, output_dir)  # noqa: F841
@@ -122,7 +121,7 @@ def view(
         style: The style used to display the output in the terminal. Must be a
             single-page style.
     """
-    address: Address = _parse_source(source)
+    address: Address = parse_source(source)
     properties: dict[str, Any] = read_properties(address)
     built_sections = _build_sections(properties, Config(style=Style[style.name]))
     console = Console(theme=_CONSOLE_THEME)

--- a/src/seedcase_flower/internals.py
+++ b/src/seedcase_flower/internals.py
@@ -1,4 +1,4 @@
-"""Helper functions for private use."""
+"""Helper functions for internal use."""
 
 import tomllib
 from dataclasses import dataclass
@@ -6,7 +6,6 @@ from importlib.resources import files
 from itertools import repeat
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, TypeVar, Union
-from urllib import parse
 
 from cyclopts.annotations import get_hint_name
 from cyclopts.help import HelpEntry
@@ -17,56 +16,6 @@ from pydantic import BaseModel, Field
 from seedcase_flower.config import Config
 from seedcase_flower.section import Content, Mode, Section
 from seedcase_flower.styles import Style
-
-
-@dataclass(frozen=True)
-class Address:
-    """A source parsed into an actual address."""
-
-    value: str
-    local: bool
-
-
-def _parse_source(source: str) -> Address:
-    split_source = parse.urlsplit(source)
-    if split_source.scheme == "":
-        split_source = split_source._replace(scheme="file")
-    match split_source.scheme:
-        case "file":
-            return _convert_to_path(split_source)
-        case "https":
-            return _convert_to_https(split_source)
-        case "gh" | "github":
-            return _convert_to_github(split_source)
-        case _:
-            raise ValueError(
-                "The source must be either a path to an existing file or "
-                "folder or have one of the following prefixes: `https:`, "
-                "`gh:`, `github:`"
-            )
-
-
-def _convert_to_path(source: parse.SplitResult) -> Address:
-    path = Path(source.path).resolve()
-    if path.is_dir():
-        path /= "datapackage.json"
-    source = source._replace(path=path.as_posix())
-    return Address(value=source.geturl(), local=True)
-
-
-def _convert_to_https(source: parse.SplitResult) -> Address:
-    return Address(value=source.geturl(), local=False)
-
-
-def _convert_to_github(source: parse.SplitResult) -> Address:
-    return Address(
-        value=source._replace(
-            scheme="https",
-            netloc="raw.githubusercontent.com",
-            path=f"/{source.path}/refs/heads/main/datapackage.json",
-        ).geturl(),
-        local=False,
-    )
 
 
 def _format_param_help(entry: HelpEntry) -> str:

--- a/src/seedcase_flower/parse_source.py
+++ b/src/seedcase_flower/parse_source.py
@@ -1,0 +1,75 @@
+"""Functions for parsing the source for a Data Package."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib import parse
+
+
+@dataclass(frozen=True)
+class Address:
+    """A source parsed into an actual address."""
+
+    value: str
+    local: bool
+
+
+def parse_source(source: str) -> Address:
+    """Parse the source of a Data Package into a formal `Address`.
+
+    Args:
+        source: The string representation for the location of a Data Package
+            metadata, either as a path, `https`, or `gh`/`github` repository.
+
+    Returns:
+        A formal `Address` class.
+
+    Raises:
+        ValueError: If the `source` contains something other than what
+            Flower can accept.
+
+    Examples:
+        ```{python}
+        import seedcase_flower as fl
+        print(fl.parse_source("./datapackage.json"))
+        print(fl.parse_source("https://raw.githubusercontent.com/seedcase-project/seedcase-flower/refs/heads/main/docs/includes/datapackage.json"))
+        ```
+    """
+    split_source = parse.urlsplit(source)
+    if split_source.scheme == "":
+        split_source = split_source._replace(scheme="file")
+    match split_source.scheme:
+        case "file":
+            return _convert_to_path(split_source)
+        case "https":
+            return _convert_to_https(split_source)
+        case "gh" | "github":
+            return _convert_to_github(split_source)
+        case _:
+            raise ValueError(
+                "The source must be either a path to an existing file or "
+                "folder or have one of the following prefixes: `https:`, "
+                "`gh:`, `github:`"
+            )
+
+
+def _convert_to_path(source: parse.SplitResult) -> Address:
+    path = Path(source.path).resolve()
+    if path.is_dir():
+        path /= "datapackage.json"
+    source = source._replace(path=path.as_posix())
+    return Address(value=source.geturl(), local=True)
+
+
+def _convert_to_https(source: parse.SplitResult) -> Address:
+    return Address(value=source.geturl(), local=False)
+
+
+def _convert_to_github(source: parse.SplitResult) -> Address:
+    return Address(
+        value=source._replace(
+            scheme="https",
+            netloc="raw.githubusercontent.com",
+            path=f"/{source.path}/refs/heads/main/datapackage.json",
+        ).geturl(),
+        local=False,
+    )

--- a/src/seedcase_flower/read_properties.py
+++ b/src/seedcase_flower/read_properties.py
@@ -7,7 +7,7 @@ from urllib import parse, request
 
 from check_datapackage import check
 
-from seedcase_flower.internals import Address
+from seedcase_flower.parse_source import Address
 
 
 def read_properties(address: Address) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,18 +11,18 @@ from rich.markdown import Markdown
 from seedcase_flower.cli import _CONSOLE_THEME, app
 from seedcase_flower.config import Config
 from seedcase_flower.internals import (
-    Address,
     BuiltSection,
     _get_template_dir,
     _load_sections,
 )
+from seedcase_flower.parse_source import Address
 from seedcase_flower.styles import Style, ViewStyle
 
 
 @pytest.fixture
 def mock_parse_source(mocker):
     """Mock _parse_source to isolate CLI tests from filesystem resolution."""
-    return mocker.patch("seedcase_flower.cli._parse_source")
+    return mocker.patch("seedcase_flower.cli.parse_source")
 
 
 @pytest.fixture
@@ -273,7 +273,7 @@ def test_view_styles_are_one_page():
 
 def test_view_with_mocked_internals(mocker):
     """view should parse source, build sections, and render via Console."""
-    mock_parse_source = mocker.patch("seedcase_flower.cli._parse_source")
+    mock_parse_source = mocker.patch("seedcase_flower.cli.parse_source")
     mock_read_properties = mocker.patch("seedcase_flower.cli.read_properties")
     mock_build_sections = mocker.patch("seedcase_flower.cli._build_sections")
     mock_console_cls = mocker.patch("seedcase_flower.cli.Console")

--- a/tests/test_parse_source.py
+++ b/tests/test_parse_source.py
@@ -1,102 +1,102 @@
-"""Tests for internal helper functions."""
+"""Tests for parsing the source for the Data Package."""
 
 import pytest
 
-from seedcase_flower.internals import Address, _parse_source
+from seedcase_flower.parse_source import Address, parse_source
 
-# _parse_source: plain path (no scheme) ====
+# parse_source: plain path (no scheme) ====
 
 
 def test_parse_source_plain_file_path_is_local(tmp_path):
     """A plain file path with no scheme should return a local Address."""
-    result = _parse_source(str(tmp_path / "datapackage.json"))
+    result = parse_source(str(tmp_path / "datapackage.json"))
     assert result.local is True
 
 
 def test_parse_source_plain_file_path_has_file_scheme(tmp_path):
     """A plain file path should be normalised to a file path."""
-    result = _parse_source(str(tmp_path / "datapackage.json"))
+    result = parse_source(str(tmp_path / "datapackage.json"))
     assert result.value.startswith("file://")
 
 
 def test_parse_source_directory_path_appends_datapackage_json(tmp_path):
     """Passing a directory path should append datapackage.json to the source."""
-    result = _parse_source(str(tmp_path))
+    result = parse_source(str(tmp_path))
     assert result.value.endswith("datapackage.json")
 
 
 def test_parse_source_directory_path_is_local(tmp_path):
     """Passing a directory path should return a local Address."""
-    result = _parse_source(str(tmp_path))
+    result = parse_source(str(tmp_path))
     assert result.local is True
 
 
-# _parse_source: file:// scheme ====
+# parse_source: file:// scheme ====
 
 
 def test_parse_source_file_scheme_is_local(tmp_path):
     """A file path should return a local Address."""
-    result = _parse_source(f"file://{tmp_path / 'datapackage.json'}")
+    result = parse_source(f"file://{tmp_path / 'datapackage.json'}")
     assert result.local is True
 
 
 def test_parse_source_file_scheme_preserves_path(tmp_path):
     """A file path pointing to a file should preserve the path."""
     file = tmp_path / "datapackage.json"
-    result = _parse_source(f"file://{file}")
+    result = parse_source(f"file://{file}")
     assert str(file) in result.value
 
 
-# _parse_source: https:// scheme ====
+# parse_source: https:// scheme ====
 
 
 def test_parse_source_https_is_not_local():
     """An https:// should return a non-local Address."""
-    result = _parse_source("https://example.com/datapackage.json")
+    result = parse_source("https://example.com/datapackage.json")
     assert result.local is False
 
 
 def test_parse_source_https_preserves_url():
     """An https:// should be returned unchanged."""
     url = "https://example.com/datapackage.json"
-    result = _parse_source(url)
+    result = parse_source(url)
     assert result.value == url
 
 
-# _parse_source: gh:// / github:// scheme ====
+# parse_source: gh:// / github:// scheme ====
 
 
 @pytest.mark.parametrize("scheme", ["gh", "github"])
 def test_parse_source_github_scheme_converts_to_raw_githubusercontent(scheme):
     """GitHub sources should be converted to a raw.githubusercontent.com URL."""
-    result = _parse_source(f"{scheme}://owner/repo")
+    result = parse_source(f"{scheme}://owner/repo")
     assert result.value.startswith("https://raw.githubusercontent.com/")
 
 
 @pytest.mark.parametrize("scheme", ["gh", "github"])
 def test_parse_source_github_scheme_is_not_local(scheme):
     """GitHub sources should return a non-local Address."""
-    result = _parse_source(f"{scheme}://owner/repo")
+    result = parse_source(f"{scheme}://owner/repo")
     assert result.local is False
 
 
 @pytest.mark.parametrize("scheme", ["gh", "github"])
 def test_parse_source_github_scheme_appends_datapackage_json(scheme):
     """GitHub sources should point to the datapackage.json on the main branch."""
-    result = _parse_source(f"{scheme}://owner/repo")
+    result = parse_source(f"{scheme}://owner/repo")
     assert result.value.endswith("datapackage.json")
 
 
-# _parse_source: unsupported scheme ====
+# parse_source: unsupported scheme ====
 
 
 def test_parse_source_unsupported_scheme_raises_value_error():
     """An unsupported source scheme should raise a ValueError."""
     with pytest.raises(ValueError, match="source must be either"):
-        _parse_source("ftp://example.com/datapackage.json")
+        parse_source("ftp://example.com/datapackage.json")
 
 
 def test_parse_source_returns_address_instance(tmp_path):
-    """_parse_source should always return a address instance."""
-    result = _parse_source(str(tmp_path / "datapackage.json"))
+    """parse_source should always return a address instance."""
+    result = parse_source(str(tmp_path / "datapackage.json"))
     assert isinstance(result, Address)

--- a/tests/test_read_properties.py
+++ b/tests/test_read_properties.py
@@ -8,7 +8,7 @@ from urllib.error import HTTPError
 import pytest
 from check_datapackage.check import DataPackageError
 
-from seedcase_flower.internals import Address, _parse_source
+from seedcase_flower.parse_source import Address, parse_source
 from seedcase_flower.read_properties import read_properties
 
 # read_properties: local file ====
@@ -24,7 +24,7 @@ def test_read_properties_local_filepath(datapackage_path, datapackage):
 
 def test_read_properties_local_dirpath(datapackage_path, datapackage):
     """Passing a path to a directory containing a datapackage.json should work."""
-    address = _parse_source(str(Path(datapackage_path).parent))
+    address = parse_source(str(Path(datapackage_path).parent))
     result = read_properties(address)
 
     assert result == datapackage


### PR DESCRIPTION
# Description

To match how we've done it with other functions.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
