### PR TITLE
build: :hammer: use `sort` on contributor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ to abide by its terms.
 The following people have contributed to this project by submitting pull
 requests :tada:
 
-[@lwjohnst86](https://github.com/lwjohnst86),
 [@joelostblom](https://github.com/joelostblom),
-[@signekb](https://github.com/signekb),
-[@martonvago](https://github.com/martonvago)
+[@lwjohnst86](https://github.com/lwjohnst86),
+[@martonvago](https://github.com/martonvago),
+[@signekb](https://github.com/signekb)
 
 ## Licensing
 

--- a/docs/includes/_contributors.qmd
+++ b/docs/includes/_contributors.qmd
@@ -1,7 +1,7 @@
-The following people have contributed to this project by submitting pull
-requests :tada:
+The following people have contributed to this project by submitting
+pull requests :tada:
 
-[\@lwjohnst86](https://github.com/lwjohnst86),
 [\@joelostblom](https://github.com/joelostblom),
-[\@signekb](https://github.com/signekb),
-[\@martonvago](https://github.com/martonvago)
+[\@lwjohnst86](https://github.com/lwjohnst86),
+[\@martonvago](https://github.com/martonvago),
+[\@signekb](https://github.com/signekb)

--- a/tools/get-contributors.sh
+++ b/tools/get-contributors.sh
@@ -11,10 +11,12 @@ contributors=$(gh api \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   /repos/$repo_spec/contributors \
-  --template '{{range .}} [\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
+  --template '{{range .}}[\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
   grep -v "\[bot\]" | \
+  sort | \
   tr '\n' ', ' | \
-  sed -e 's/,$/\n/'
+  sed -e 's/,$/\n/' | \
+  sed -e 's/,/,\n/g'
 )
 
-echo "The following people have contributed to this project by submitting pull requests :tada:\n\n${contributors}"
+echo "The following people have contributed to this project by submitting\npull requests :tada:\n\n${contributors}"


### PR DESCRIPTION
# Description

It normally orders by number of contributions, which means it changes whenever that order changes. This change will make sure that the changes are always consistent whenever rebuilding the contributor list.

No review needed.
