### PR TITLE
build: :hammer: newline after 'pull' to match rumdl formatter

### DIFF
--- a/docs/includes/_contributors.qmd
+++ b/docs/includes/_contributors.qmd
@@ -1,5 +1,5 @@
-The following people have contributed to this project by submitting
-pull requests :tada:
+The following people have contributed to this project by submitting pull
+requests :tada:
 
 [\@joelostblom](https://github.com/joelostblom),
 [\@lwjohnst86](https://github.com/lwjohnst86),

--- a/tools/get-contributors.sh
+++ b/tools/get-contributors.sh
@@ -19,4 +19,4 @@ contributors=$(gh api \
   sed -e 's/,/,\n/g'
 )
 
-echo "The following people have contributed to this project by submitting\npull requests :tada:\n\n${contributors}"
+echo "The following people have contributed to this project by submitting pull\nrequests :tada:\n\n${contributors}"


### PR DESCRIPTION
# Description

This corrects the contributor list tool so it matches rumdl formatter.

Needs no review.

## Checklist

- [x] Ran `just run-all`
