### PR TITLE
feat: ✨ suppress tracebacks from all errors when running from the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ changelog = "https://github.com/seedcase-project/seedcase-flower/blob/main/CHANG
 issues = "https://github.com/seedcase-project/seedcase-flower/issues"
 
 [project.scripts]
-seedcase-flower = "seedcase_flower.cli:app"
+seedcase-flower = "seedcase_flower.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 from cyclopts import App, Parameter, config
 from cyclopts.help import ColumnSpec, DefaultFormatter, DescriptionRenderer
 from rich import box
+from rich import print as rprint
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.theme import Theme
@@ -142,3 +143,12 @@ def view(
     console = Console(theme=_CONSOLE_THEME)
     print()  # One line separation between the command and the datapackage title
     console.print(Markdown(built_sections[0].content))
+
+
+def main() -> None:
+    """Suppress traceback when running from CLI."""
+    try:
+        app()
+    except Exception as e:
+        rprint(f"\n[red]{type(e).__name__}[/red]: {e}")
+        raise SystemExit(1)


### PR DESCRIPTION
# Description

After deciding to only suppress errors when running from the CLI, we can go with this is much simpler approach instead of of modifying `sys.excepthook`.

I think this is looking good from a UX perspective:

<img width="959" height="447" alt="image" src="https://github.com/user-attachments/assets/3156ea7e-4721-4edd-b763-5dfd4126f1fb" />

Importantly, cyclopts own error handling still works it seems:

<img width="957" height="114" alt="image" src="https://github.com/user-attachments/assets/545d200a-4410-40f1-8c29-69def7ba7f36" />

I don't know what other gotchas there might be from doing this, any thoughts?

Closes https://github.com/seedcase-project/check-datapackage/issues/313 (in check-datapackage).

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
