### PR TITLE
feat: ✨ match cyclopts error decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ each release.
 
 ### Feat
 
-- ✨ suppress tracebacks from all errors when running from the CLI (#216)
+- ✨ suppress tracebacks from all errors when running from the CLI
+  (#216)
 
 ## 0.18.0 (2026-03-25)
 

--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -6,9 +6,11 @@ from typing import Any, Optional
 from cyclopts import App, Parameter, config
 from cyclopts.help import ColumnSpec, DefaultFormatter, DescriptionRenderer
 from rich import box
-from rich import print as rprint
 from rich.console import Console
+from rich.highlighter import ReprHighlighter
 from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.text import Text
 from rich.theme import Theme
 
 from seedcase_flower.build_sections import build_sections
@@ -145,10 +147,26 @@ def view(
     console.print(Markdown(built_sections[0].content))
 
 
+def _pretty_print_error(e: Exception) -> None:
+    console = Console(stderr=True)
+    text = Text.from_markup(str(e))
+    # Make `text` appear as if it was printed by rich.print
+    pretty_text = ReprHighlighter()(text)
+    console.print(
+        Panel(
+            pretty_text,
+            title=type(e).__name__,
+            border_style="red",
+            box=box.ROUNDED,
+            title_align="left",
+        )
+    )
+
+
 def main() -> None:
     """Suppress traceback when running from CLI."""
     try:
         app()
     except Exception as e:
-        rprint(f"\n[red]{type(e).__name__}[/red]: {e}")
+        _pretty_print_error(e)
         raise SystemExit(1)


### PR DESCRIPTION
# Description

This turned out to be quite straightforward and I like the look! Curious if you all prefer this or the old format.

Before this PR:
<img width="959" height="447" alt="image" src="https://github.com/user-attachments/assets/e28137cc-babd-4d15-ac25-ad14769ea100" />

After this PR:
<img width="959" height="489" alt="image" src="https://github.com/user-attachments/assets/22179021-d3f2-4f46-b1c9-dbbae6de993e" />

Cyclopts error for comparison:
<img width="957" height="114" alt="image" src="https://github.com/user-attachments/assets/7000f7f3-756c-421a-abdd-b7c7ec1ce002" />

As with my previous PR, I think this should eventually be *soiled*™ so we can use it across packages. Will rebase after #216 is merged.

Closes #218 

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
