### PR TITLE
fix: 🐛 make styles follow commonmark/rumdl format

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -8,7 +8,9 @@ exclude = [
     # This is auto-generated from the qmd version
     "**/README.md",
     # This has it's own structure
-    "**/LICENSE.md"
+    "**/LICENSE.md",
+    # Generated example output (subdirectories only)
+    "docs/examples/**"
 ]
 
 # List style: `-`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ each release.
 
 ### Feat
 
-- ✨ suppress tracebacks from all errors when running from the CLI (#216)
+- ✨ suppress tracebacks from all errors when running from the CLI
+  (#216)
 
 ## 0.18.0 (2026-03-25)
 

--- a/docs/examples/quarto-one-page/index.qmd
+++ b/docs/examples/quarto-one-page/index.qmd
@@ -5,7 +5,6 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 
 # `flora`: Observations of flora species and seasonal development
 
-
 **Licenses:**
 
 - [CCO 1.0 UNIVERSAL](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
@@ -13,7 +12,8 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 
 **Version:** 1.2.3
 
-A dataset containing flora species records and their observed growth stages across different environments.
+A dataset containing flora species records and their observed growth
+stages across different environments.
 
 ## Contributors
 
@@ -58,7 +58,8 @@ This resource contains a catalog of flora species locations.
 
 ### `growth_records`: Growth Stage Records
 
-This resource contains records of observed growth stages for various flora species.
+This resource contains records of observed growth stages for various
+flora species.
 
 - Path: `resources/growth_records/data.parquet`
 - Primary key: (`record_id`)

--- a/docs/examples/quarto-one-page/index.qmd
+++ b/docs/examples/quarto-one-page/index.qmd
@@ -29,8 +29,8 @@ This resource contains a catalog of flora species.
 - Path: `resources/species_catalog/data.parquet`
 - Primary key: (`species_id`)
 - Foreign keys:
-    - From fields (`parent_species_id`) to fields (`species_id`) in
-      resource `species_catalog`
+  - From fields (`parent_species_id`) to fields (`species_id`) in
+    resource `species_catalog`
 
 | Title           | Name                | Type    | Description                                    |
 |-----------------|---------------------|---------|------------------------------------------------|
@@ -65,10 +65,10 @@ flora species.
 - Path: `resources/growth_records/data.parquet`
 - Primary key: (`record_id`)
 - Foreign keys:
-    - From fields (`species_id`) to fields (`species_id`) in resource
-      `species_catalog`
-    - From fields (`location_region`, `location_country`) to fields
-      (`region`, `country`) in resource `location_catalog`
+  - From fields (`species_id`) to fields (`species_id`) in resource
+    `species_catalog`
+  - From fields (`location_region`, `location_country`) to fields
+    (`region`, `country`) in resource `location_catalog`
 
 | Title            | Name               | Type    | Description                                   |
 |------------------|--------------------|---------|-----------------------------------------------|

--- a/docs/examples/quarto-one-page/index.qmd
+++ b/docs/examples/quarto-one-page/index.qmd
@@ -29,7 +29,8 @@ This resource contains a catalog of flora species.
 - Path: `resources/species_catalog/data.parquet`
 - Primary key: (`species_id`)
 - Foreign keys:
-    - From fields (`parent_species_id`) to fields (`species_id`) in resource `species_catalog`
+    - From fields (`parent_species_id`) to fields (`species_id`) in
+      resource `species_catalog`
 
 | Title           | Name                | Type    | Description                                    |
 |-----------------|---------------------|---------|------------------------------------------------|
@@ -64,8 +65,10 @@ flora species.
 - Path: `resources/growth_records/data.parquet`
 - Primary key: (`record_id`)
 - Foreign keys:
-    - From fields (`species_id`) to fields (`species_id`) in resource `species_catalog`
-    - From fields (`location_region`, `location_country`) to fields (`region`, `country`) in resource `location_catalog`
+    - From fields (`species_id`) to fields (`species_id`) in resource
+      `species_catalog`
+    - From fields (`location_region`, `location_country`) to fields
+      (`region`, `country`) in resource `location_catalog`
 
 | Title            | Name               | Type    | Description                                   |
 |------------------|--------------------|---------|-----------------------------------------------|

--- a/docs/examples/quarto-one-page/index.qmd
+++ b/docs/examples/quarto-one-page/index.qmd
@@ -12,8 +12,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 
 **Version:** 1.2.3
 
-A dataset containing flora species records and their observed growth
-stages across different environments.
+A dataset containing flora species records and their observed growth stages across different environments.
 
 ## Contributors
 
@@ -29,8 +28,7 @@ This resource contains a catalog of flora species.
 - Path: `resources/species_catalog/data.parquet`
 - Primary key: (`species_id`)
 - Foreign keys:
-  - From fields (`parent_species_id`) to fields (`species_id`) in
-    resource `species_catalog`
+  - From fields (`parent_species_id`) to fields (`species_id`) in resource `species_catalog`
 
 | Title           | Name                | Type    | Description                                    |
 |-----------------|---------------------|---------|------------------------------------------------|
@@ -59,16 +57,13 @@ This resource contains a catalog of flora species locations.
 
 ### `growth_records`: Growth Stage Records
 
-This resource contains records of observed growth stages for various
-flora species.
+This resource contains records of observed growth stages for various flora species.
 
 - Path: `resources/growth_records/data.parquet`
 - Primary key: (`record_id`)
 - Foreign keys:
-  - From fields (`species_id`) to fields (`species_id`) in resource
-    `species_catalog`
-  - From fields (`location_region`, `location_country`) to fields
-    (`region`, `country`) in resource `location_catalog`
+  - From fields (`species_id`) to fields (`species_id`) in resource `species_catalog`
+  - From fields (`location_region`, `location_country`) to fields (`region`, `country`) in resource `location_catalog`
 
 | Title            | Name               | Type    | Description                                   |
 |------------------|--------------------|---------|-----------------------------------------------|

--- a/docs/examples/quarto-one-page/index.qmd
+++ b/docs/examples/quarto-one-page/index.qmd
@@ -8,8 +8,8 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 
 **Licenses:**
 
--   [CCO 1.0 UNIVERSAL](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
--   [Academic Free License 3.0](https://opensource.org/licenses/AFL-3.0)
+- [CCO 1.0 UNIVERSAL](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+- [Academic Free License 3.0](https://opensource.org/licenses/AFL-3.0)
 
 **Version:** 1.2.3
 
@@ -17,8 +17,8 @@ A dataset containing flora species records and their observed growth stages acro
 
 ## Contributors
 
--   Jane Dölitz (<jane-doelitz@example.com>): creator
--   John Smith (<john-smith@example.com>): author, data collector
+- Jane Dölitz (<jane-doelitz@example.com>): creator
+- John Smith (<john-smith@example.com>): author, data collector
 
 ## Resources
 
@@ -26,18 +26,18 @@ A dataset containing flora species records and their observed growth stages acro
 
 This resource contains a catalog of flora species.
 
--   Path: `resources/species_catalog/data.parquet`
--   Primary key: (`species_id`)
--   Foreign keys:
-    -   From fields (`parent_species_id`) to fields (`species_id`) in resource `species_catalog`
+- Path: `resources/species_catalog/data.parquet`
+- Primary key: (`species_id`)
+- Foreign keys:
+    - From fields (`parent_species_id`) to fields (`species_id`) in resource `species_catalog`
 
-| Title | Name | Type | Description |
-|-------|------|------|-------------|
-| Species ID | `species_id` | integer | The unique identifier for each species. |
-| Scientific name | `scientific_name` | string | The Latin name of the species. |
-| Common name | `common_name` | string | The common name of the species. |
-| Family | `family` | string | The Latin family to which the species belongs. |
-| Parent Species | `parent_species_id` | integer | The parent species of this species. |
+| Title           | Name                | Type    | Description                                    |
+|-----------------|---------------------|---------|------------------------------------------------|
+| Species ID      | `species_id`        | integer | The unique identifier for each species.        |
+| Scientific name | `scientific_name`   | string  | The Latin name of the species.                 |
+| Common name     | `common_name`       | string  | The common name of the species.                |
+| Family          | `family`            | string  | The Latin family to which the species belongs. |
+| Parent Species  | `parent_species_id` | integer | The parent species of this species.            |
 
 : Fields in the `species_catalog` resource.
 
@@ -45,13 +45,13 @@ This resource contains a catalog of flora species.
 
 This resource contains a catalog of flora species locations.
 
--   Path: `resources/location_catalog/data.parquet`
--   Primary key: (`region`, `country`)
+- Path: `resources/location_catalog/data.parquet`
+- Primary key: (`region`, `country`)
 
-| Title | Name | Type | Description |
-|-------|------|------|-------------|
-| Region | `region` | string | The region the location is in. |
-| Country | `country` | string | The country the location is in. |
+| Title      | Name         | Type   | Description                                     |
+|------------|--------------|--------|-------------------------------------------------|
+| Region     | `region`     | string | The region the location is in.                  |
+| Country    | `country`    | string | The country the location is in.                 |
 | Local Name | `local_name` | string | The name of the location in the local language. |
 
 : Fields in the `location_catalog` resource.
@@ -60,19 +60,19 @@ This resource contains a catalog of flora species locations.
 
 This resource contains records of observed growth stages for various flora species.
 
--   Path: `resources/growth_records/data.parquet`
--   Primary key: (`record_id`)
--   Foreign keys:
-    -   From fields (`species_id`) to fields (`species_id`) in resource `species_catalog`
-    -   From fields (`location_region`, `location_country`) to fields (`region`, `country`) in resource `location_catalog`
+- Path: `resources/growth_records/data.parquet`
+- Primary key: (`record_id`)
+- Foreign keys:
+    - From fields (`species_id`) to fields (`species_id`) in resource `species_catalog`
+    - From fields (`location_region`, `location_country`) to fields (`region`, `country`) in resource `location_catalog`
 
-| Title | Name | Type | Description |
-|-------|------|------|-------------|
-| Record ID | `record_id` | integer | The unique identifier for each growth record. |
-| Species | `species_id` | integer | The species the observation was made for. |
-| Observation date | `observation_date` | date | The date when the observation was made. |
-| Growth Stage | `growth_stage` | string | The observed growth stage of the species. |
-| Location Region | `location_region` | string | The region of the location. |
-| Location Country | `location_country` | string | The country of the location. |
+| Title            | Name               | Type    | Description                                   |
+|------------------|--------------------|---------|-----------------------------------------------|
+| Record ID        | `record_id`        | integer | The unique identifier for each growth record. |
+| Species          | `species_id`       | integer | The species the observation was made for.     |
+| Observation date | `observation_date` | date    | The date when the observation was made.       |
+| Growth Stage     | `growth_stage`     | string  | The observed growth stage of the species.     |
+| Location Region  | `location_region`  | string  | The region of the location.                   |
+| Location Country | `location_country` | string  | The country of the location.                  |
 
 : Fields in the `growth_records` resource.

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -85,7 +85,7 @@ def _cell_width(headers: list[str], rows: list[list[str]], col: int) -> int:
 
 
 def _column_widths(headers: list[str], rows: list[list[str]]) -> list[int]:
-    return list(map(lambda i: _cell_width(headers, rows, i), range(len(headers))))
+    return _map(range(len(headers)), lambda i: _cell_width(headers, rows, i))
 
 
 def _format_row(row: list[str], widths: list[int]) -> str:

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -76,6 +76,30 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
+def _render_markdown_table(headers: list[str], rows: list[list[str]]) -> str:
+    """Renders a markdown table with column widths adjusted to content."""
+    if not headers:
+        return ""
+
+    num_cols = len(headers)
+    widths = [
+        max(len(headers[i]), max((len(row[i]) for row in rows), default=0))
+        for i in range(num_cols)
+    ]
+
+    def pad(value: str, width: int) -> str:
+        return value.ljust(width)
+
+    header_row = "| " + " | ".join(pad(h, w) for h, w in zip(headers, widths)) + " |"
+    sep_row = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
+    data_rows = [
+        "| " + " | ".join(pad(cell, w) for cell, w in zip(row, widths)) + " |"
+        for row in rows
+    ]
+
+    return "\n".join([header_row, sep_row] + data_rows)
+
+
 def _create_jinja_env(template_dir: Path) -> Environment:
     env = Environment(
         loader=FileSystemLoader(template_dir),
@@ -92,6 +116,8 @@ def _create_jinja_env(template_dir: Path) -> Environment:
     env.filters["_inline_code_list"] = _inline_code_list
     # Render a single value as inline code
     env.filters["_inline_code"] = _inline_code
+    # Render a markdown table with adjusted column widths
+    env.globals["_render_markdown_table"] = _render_markdown_table
     return env
 
 

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -1,8 +1,6 @@
 """Build sections from templates."""
 
 import tomllib
-import re
-import textwrap
 from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
@@ -78,66 +76,6 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
-def _wrap_text(value: str, width: int = 72) -> str:
-    """Wrap text to a maximum line width, preserving list indentation.
-
-    Skips headers (lines starting with #), tables (lines containing |),
-    HTML comments (lines between <!-- and -->), and markdown links.
-    """
-    if not value:
-        return value
-
-    def is_header(line: str) -> bool:
-        return line.lstrip().startswith("#")
-
-    def is_table(line: str) -> bool:
-        return "|" in line
-
-    def is_link(line: str) -> bool:
-        return bool(re.search(r"\[[^\]]+\]\([^)]+\)", line))
-
-    def is_list_item(line: str) -> bool:
-        return bool(re.match(r"^(\s*)([-*]|\d+\.)\s+", line))
-
-    def wrap_list_item(line: str) -> str:
-        match = re.match(r"^(\s*)([-*]|\d+\.)\s+(.*)", line)
-        leading_spaces = match.group(1)
-        bullet = match.group(2)
-        content = match.group(3)
-        subsequent_indent = leading_spaces + " " * (len(bullet) + 1)
-
-        return textwrap.fill(
-            content,
-            width=width,
-            initial_indent=leading_spaces + bullet + " ",
-            subsequent_indent=subsequent_indent,
-        )
-
-    lines = value.split("\n")
-    result = []
-    in_comment = False
-
-    for line in lines:
-        if "<!--" in line:
-            in_comment = True
-        if in_comment:
-            result.append(line)
-            if "-->" in line:
-                in_comment = False
-            continue
-
-        if is_header(line) or is_table(line) or is_link(line):
-            result.append(line)
-        elif is_list_item(line):
-            result.append(wrap_list_item(line))
-        elif line.strip():
-            result.append(textwrap.fill(line, width=width))
-        else:
-            result.append(line)
-
-    return "\n".join(result)
-
-
 def _max_column_width(rows: list[list[str]], col: int) -> int:
     return max(map(lambda row: len(row[col]), rows), default=0)
 
@@ -189,8 +127,6 @@ def _create_jinja_env(template_dir: Path) -> Environment:
     env.filters["_inline_code_list"] = _inline_code_list
     # Render a single value as inline code
     env.filters["_inline_code"] = _inline_code
-    # Wrap text to a maximum line width
-    env.filters["_wrap_text"] = _wrap_text
     # Render a markdown table with adjusted column widths
     env.globals["_render_markdown_table"] = _render_markdown_table
     return env
@@ -237,7 +173,7 @@ def _build_one(
     )
     return BuiltSection(
         output_path=one.output_path,
-        content=_wrap_text("\n".join(built_contents)),
+        content="\n".join(built_contents),
     )
 
 
@@ -274,9 +210,7 @@ def _build_many(
         matches,
         lambda match: BuiltSection(
             output_path=_get_output_path_for_match(match, many),
-            content=_wrap_text(
-                template.render(**{many.jinja_variable: match.properties})
-            ),
+            content=template.render(**{many.jinja_variable: match.properties}),
         ),
     )
 

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -79,9 +79,19 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
 
 
 def _wrap_text(value: str, width: int = 72) -> str:
-    """Wrap text to a maximum line width, preserving list indentation."""
+    """Wrap text to a maximum line width, preserving list indentation.
+
+    Skips headers (lines starting with #), tables (lines containing |),
+    and HTML comments (lines between <!-- and -->).
+    """
     if not value:
         return value
+
+    def is_header(line: str) -> bool:
+        return line.lstrip().startswith("#")
+
+    def is_table(line: str) -> bool:
+        return "|" in line
 
     def is_list_item(line: str) -> bool:
         return bool(re.match(r"^(\s*)([-*]|\d+\.)\s+", line))
@@ -100,12 +110,29 @@ def _wrap_text(value: str, width: int = 72) -> str:
             subsequent_indent=subsequent_indent,
         )
 
-    def wrap_line(line: str) -> str:
-        if is_list_item(line):
-            return wrap_list_item(line)
-        return textwrap.fill(line, width=width) if line.strip() else line
+    lines = value.split("\n")
+    result = []
+    in_comment = False
 
-    return "\n".join(map(wrap_line, value.split("\n")))
+    for line in lines:
+        if "<!--" in line:
+            in_comment = True
+        if in_comment:
+            result.append(line)
+            if "-->" in line:
+                in_comment = False
+            continue
+
+        if is_header(line) or is_table(line):
+            result.append(line)
+        elif is_list_item(line):
+            result.append(wrap_list_item(line))
+        elif line.strip():
+            result.append(textwrap.fill(line, width=width))
+        else:
+            result.append(line)
+
+    return "\n".join(result)
 
 
 def _max_column_width(rows: list[list[str]], col: int) -> int:
@@ -207,7 +234,7 @@ def _build_one(
     )
     return BuiltSection(
         output_path=one.output_path,
-        content="\n".join(built_contents),
+        content=_wrap_text("\n".join(built_contents)),
     )
 
 
@@ -244,7 +271,9 @@ def _build_many(
         matches,
         lambda match: BuiltSection(
             output_path=_get_output_path_for_match(match, many),
-            content=template.render(**{many.jinja_variable: match.properties}),
+            content=_wrap_text(
+                template.render(**{many.jinja_variable: match.properties})
+            ),
         ),
     )
 

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -76,28 +76,39 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
+def _max_column_width(rows: list[list[str]], col: int) -> int:
+    return max(map(lambda row: len(row[col]), rows), default=0)
+
+
+def _cell_width(headers: list[str], rows: list[list[str]], col: int) -> int:
+    return max(len(headers[col]), _max_column_width(rows, col))
+
+
+def _column_widths(headers: list[str], rows: list[list[str]]) -> list[int]:
+    return list(map(lambda i: _cell_width(headers, rows, i), range(len(headers))))
+
+
+def _format_row(row: list[str], widths: list[int]) -> str:
+    return "| " + " | ".join(map(str.ljust, row, widths)) + " |"
+
+
+def _separator_row(widths: list[int]) -> str:
+    return "|" + "|".join(map(lambda w: "-" * (w + 2), widths)) + "|"
+
+
 def _render_markdown_table(headers: list[str], rows: list[list[str]]) -> str:
-    """Renders a markdown table with column widths adjusted to content."""
     if not headers:
         return ""
 
-    num_cols = len(headers)
-    widths = [
-        max(len(headers[i]), max((len(row[i]) for row in rows), default=0))
-        for i in range(num_cols)
-    ]
+    widths = _column_widths(headers, rows)
 
-    def pad(value: str, width: int) -> str:
-        return value.ljust(width)
-
-    header_row = "| " + " | ".join(pad(h, w) for h, w in zip(headers, widths)) + " |"
-    sep_row = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
-    data_rows = [
-        "| " + " | ".join(pad(cell, w) for cell, w in zip(row, widths)) + " |"
-        for row in rows
-    ]
-
-    return "\n".join([header_row, sep_row] + data_rows)
+    return "\n".join(
+        [
+            _format_row(headers, widths),
+            _separator_row(widths),
+            *map(lambda row: _format_row(row, widths), rows),
+        ]
+    )
 
 
 def _create_jinja_env(template_dir: Path) -> Environment:

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -82,7 +82,7 @@ def _wrap_text(value: str, width: int = 72) -> str:
     """Wrap text to a maximum line width, preserving list indentation.
 
     Skips headers (lines starting with #), tables (lines containing |),
-    and HTML comments (lines between <!-- and -->).
+    HTML comments (lines between <!-- and -->), and markdown links.
     """
     if not value:
         return value
@@ -92,6 +92,9 @@ def _wrap_text(value: str, width: int = 72) -> str:
 
     def is_table(line: str) -> bool:
         return "|" in line
+
+    def is_link(line: str) -> bool:
+        return bool(re.search(r"\[[^\]]+\]\([^)]+\)", line))
 
     def is_list_item(line: str) -> bool:
         return bool(re.match(r"^(\s*)([-*]|\d+\.)\s+", line))
@@ -123,7 +126,7 @@ def _wrap_text(value: str, width: int = 72) -> str:
                 in_comment = False
             continue
 
-        if is_header(line) or is_table(line):
+        if is_header(line) or is_table(line) or is_link(line):
             result.append(line)
         elif is_list_item(line):
             result.append(wrap_list_item(line))

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -1,6 +1,8 @@
 """Build sections from templates."""
 
 import tomllib
+import re
+import textwrap
 from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
@@ -76,6 +78,36 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
+def _wrap_text(value: str, width: int = 72) -> str:
+    """Wrap text to a maximum line width, preserving list indentation."""
+    if not value:
+        return value
+
+    def is_list_item(line: str) -> bool:
+        return bool(re.match(r"^(\s*)([-*]|\d+\.)\s+", line))
+
+    def wrap_list_item(line: str) -> str:
+        match = re.match(r"^(\s*)([-*]|\d+\.)\s+(.*)", line)
+        leading_spaces = match.group(1)
+        bullet = match.group(2)
+        content = match.group(3)
+        subsequent_indent = leading_spaces + " " * (len(bullet) + 1)
+
+        return textwrap.fill(
+            content,
+            width=width,
+            initial_indent=leading_spaces + bullet + " ",
+            subsequent_indent=subsequent_indent,
+        )
+
+    def wrap_line(line: str) -> str:
+        if is_list_item(line):
+            return wrap_list_item(line)
+        return textwrap.fill(line, width=width) if line.strip() else line
+
+    return "\n".join(map(wrap_line, value.split("\n")))
+
+
 def _max_column_width(rows: list[list[str]], col: int) -> int:
     return max(map(lambda row: len(row[col]), rows), default=0)
 
@@ -127,6 +159,8 @@ def _create_jinja_env(template_dir: Path) -> Environment:
     env.filters["_inline_code_list"] = _inline_code_list
     # Render a single value as inline code
     env.filters["_inline_code"] = _inline_code
+    # Wrap text to a maximum line width
+    env.filters["_wrap_text"] = _wrap_text
     # Render a markdown table with adjusted column widths
     env.globals["_render_markdown_table"] = _render_markdown_table
     return env

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -24,7 +24,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endif %}
 {% if package.description %}
 
-{{ package.description }}
+{{ package.description | _wrap_text }}
 {% endif %}
 {% if package.contributors %}
 
@@ -46,7 +46,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 ### {{ resource.name | _inline_code }}{{ ": " ~ resource.title if resource.title }}
 {% if resource.description %}
 
-{{ resource.description }}
+{{ resource.description | _wrap_text }}
 {% endif %}
 {% if resource.path %}
 

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -13,9 +13,9 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 
 {% for license in package.licenses %}
 {% if license.path %}
--   [{{ license.title or license.name or "License" }}]({{ license.path }})
+- [{{ license.title or license.name or "License" }}]({{ license.path }})
 {% else %}
--   {{ license.title or license.name }}
+- {{ license.title or license.name }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -36,7 +36,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% set email = "<" ~ contributor.email ~ ">" if contributor.email %}
 {% set roles = contributor.roles | join(', ') %}
 {% if label or email %}
--   {{ label or email }}{{ " (" ~ email ~ ")" if label and email }}{{ ": " ~ roles if roles }}
+- {{ label or email }}{{ " (" ~ email ~ ")" if label and email }}{{ ": " ~ roles if roles }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -51,17 +51,17 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endif %}
 {% if resource.path %}
 
--   Path: {{ resource.path | _inline_code }}
+- Path: {{ resource.path | _inline_code }}
 {% endif %}
 {% if resource.schema %}
 {% set schema = resource.schema %}
 {% if schema.primaryKey %}
--   Primary key: ({{ schema.primaryKey | _inline_code_list }})
+- Primary key: ({{ schema.primaryKey | _inline_code_list }})
 {% endif %}
 {% if schema.foreignKeys %}
--   Foreign keys:
+- Foreign keys:
 {% for fk in schema.foreignKeys %}
-    -   From fields ({{
+    - From fields ({{
         fk.fields | _inline_code_list
     }}) to fields ({{
         fk.reference.fields | _inline_code_list

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -8,7 +8,6 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endif %}
 
 {% if package.licenses %}
-
 **Licenses:**
 
 {% for license in package.licenses %}

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -72,11 +72,17 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endfor %}
 {% endif %}
 
-| Title | Name | Type | Description |
-|-------|------|------|-------------|
-{% for field in schema.fields %}
-| {{ field.title or "N/A" }} | {{ field.name | _inline_code}} | {{ field.type or "any" }} | {{ field.description or "N/A" }} |
-{% endfor %}
+{%- set headers = ["Title", "Name", "Type", "Description"] -%}
+{%- set ns = namespace(rows=[]) -%}
+{%- for field in schema.fields -%}
+  {%- set ns.rows = ns.rows + [[
+    field.title or "N/A",
+    field.name | _inline_code or "N/A",
+    field.type or "any",
+    field.description or "N/A"
+  ]] -%}
+{%- endfor -%}
+{{ _render_markdown_table(headers, ns.rows) }}
 
 : Fields in the {{ resource.name | _inline_code }} resource.
 {% endif %}

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -24,7 +24,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endif %}
 {% if package.description %}
 
-{{ package.description | _wrap_text }}
+{{ package.description }}
 {% endif %}
 {% if package.contributors %}
 
@@ -46,7 +46,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 ### {{ resource.name | _inline_code }}{{ ": " ~ resource.title if resource.title }}
 {% if resource.description %}
 
-{{ resource.description | _wrap_text }}
+{{ resource.description }}
 {% endif %}
 {% if resource.path %}
 
@@ -60,12 +60,14 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% if schema.foreignKeys %}
 - Foreign keys:
 {% for fk in schema.foreignKeys %}
-{% set from_fields = fk.fields | _inline_code_list %}
-{% set to_fields = fk.reference.fields | _inline_code_list %}
-{% set to_resource = (fk.reference.resource or resource.name) | _inline_code %}
-{% set fk_text = "From fields (" ~ from_fields ~ ") to fields (" ~ to_fields ~ ") in resource " ~ to_resource %}
-{% set fk_line = "    - " ~ fk_text %}
-{{ fk_line | _wrap_text }}
+    - From fields ({{
+        fk.fields | _inline_code_list
+    }}) to fields ({{
+        fk.reference.fields | _inline_code_list
+    }}) in resource {{
+      (fk.reference.resource or resource.name)
+      | _inline_code
+    }}
 {% endfor %}
 {% endif %}
 

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -60,14 +60,12 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% if schema.foreignKeys %}
 - Foreign keys:
 {% for fk in schema.foreignKeys %}
-    - From fields ({{
-        fk.fields | _inline_code_list
-    }}) to fields ({{
-        fk.reference.fields | _inline_code_list
-    }}) in resource {{
-      (fk.reference.resource or resource.name)
-      | _inline_code
-    }}
+{% set from_fields = fk.fields | _inline_code_list %}
+{% set to_fields = fk.reference.fields | _inline_code_list %}
+{% set to_resource = (fk.reference.resource or resource.name) | _inline_code %}
+{% set fk_text = "From fields (" ~ from_fields ~ ") to fields (" ~ to_fields ~ ") in resource " ~ to_resource %}
+{% set fk_line = "    - " ~ fk_text %}
+{{ fk_line | _wrap_text }}
 {% endfor %}
 {% endif %}
 

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -72,7 +72,7 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% endfor %}
 {% endif %}
 
-{%- set headers = ["Title", "Name", "Type", "Description"] -%}
+{% set headers = ["Title", "Name", "Type", "Description"] %}
 {%- set ns = namespace(rows=[]) -%}
 {%- for field in schema.fields -%}
   {%- set ns.rows = ns.rows + [[

--- a/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
+++ b/src/seedcase_flower/styles/quarto_one_page/package.qmd.jinja
@@ -60,14 +60,14 @@ If you want to edit the content, please make changes to the `datapackage.json` f
 {% if schema.foreignKeys %}
 - Foreign keys:
 {% for fk in schema.foreignKeys %}
-    - From fields ({{
-        fk.fields | _inline_code_list
-    }}) to fields ({{
-        fk.reference.fields | _inline_code_list
-    }}) in resource {{
-      (fk.reference.resource or resource.name)
-      | _inline_code
-    }}
+  - From fields ({{
+      fk.fields | _inline_code_list
+  }}) to fields ({{
+      fk.reference.fields | _inline_code_list
+  }}) in resource {{
+    (fk.reference.resource or resource.name)
+    | _inline_code
+  }}
 {% endfor %}
 {% endif %}
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,15 +17,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -535,9 +535,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/c4/2ce2ca1451487dc7d59f09334c3fa1182c46cfcf0a2d5f19f9b26d53ac74/cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0", size = 166623, upload-time = "2026-03-23T14:43:01.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/06/d68a5d5d292c2ad2bc6a02e5ca2cb1bb9c15e941ab02f004a06a342d7f0f/cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7", size = 204097, upload-time = "2026-03-14T14:09:32.504Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/2261922126b2e50c601fe22d7ff5194e0a4d50e654836260c0665e24d862/cyclopts-4.10.1-py3-none-any.whl", hash = "sha256:35f37257139380a386d9fe4475e1e7c87ca7795765ef4f31abba579fcfcb6ecd", size = 204331, upload-time = "2026-03-23T14:43:02.625Z" },
 ]
 
 [[package]]
@@ -680,34 +680,37 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/6a3b9fdc20650777e77c6cca1aeea5067291ff056665b4fec528d823127f/griffe-2.0.1.tar.gz", hash = "sha256:87e2483145669334d4b595b459a7bd58ab92037c20c63c9d882ead0c0f7ca5b6", size = 293702, upload-time = "2026-03-23T21:05:27.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/05/2f817197fe8f63398df6e94e698794bddc50564434683fca4158a8d913a6/griffe-2.0.1-py3-none-any.whl", hash = "sha256:7ebbefa657cb20c035552176425f3a9acef1a3a73619a469fa4088a2fbf2a4c1", size = 5140, upload-time = "2026-03-23T21:04:02.257Z" },
 ]
 
 [[package]]
 name = "griffecli"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/e4/41882f30d4c5d842d32cc91c9a60d2c566309b6f1c773864fb1758d6a2f2/griffecli-2.0.1.tar.gz", hash = "sha256:a44f1482dfbeea72bd6686a4e7c99e0d30b0d2abd675b81e9ac1d97734ca7cf6", size = 56199, upload-time = "2026-03-23T21:05:24.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e5/d3161a36107fd23c86385354a16f0e2d204f7b2c8db80d10fbd28447e5f5/griffecli-2.0.1-py3-none-any.whl", hash = "sha256:5c89012c292365c20538740cf491443625b3083449516964f4d3de3ca8c36090", size = 9342, upload-time = "2026-03-23T21:04:03.385Z" },
 ]
 
 [[package]]
 name = "griffelib"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/d7/2b805e89cdc609e5b304361d80586b272ef00f6287ee63de1e571b1f71ec/griffelib-2.0.1.tar.gz", hash = "sha256:59f39eabb4c777483a3823e39e8f9e03e69df271a7e49aee64e91a8cfa91bdf5", size = 166383, upload-time = "2026-03-23T21:05:25.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/cc8c68196db727cfc1432f2ad5de50aa6707e630d44b2e6361dc06d8f134/griffelib-2.0.1-py3-none-any.whl", hash = "sha256:b769eed581c0e857d362fc8fcd8e57ecd2330c124b6104ac8b4c1c86d76970aa", size = 142377, upload-time = "2026-03-23T21:04:01.116Z" },
 ]
 
 [[package]]
@@ -915,11 +918,11 @@ wheels = [
 
 [[package]]
 name = "jsonpointer"
-version = "3.0.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]
@@ -1837,16 +1840,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -2367,16 +2370,16 @@ wheels = [
 
 [[package]]
 name = "sphobjinv"
-version = "2.3.1.3"
+version = "2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "certifi" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/4887ebe7b46f4669a896dc286a3ac559101d2ceadbbea4614472960c2222/sphobjinv-2.3.1.3.tar.gz", hash = "sha256:a1d51e4cf3d968b9e0d3ed1cbccea0071e5e5795f24a2d7401a4e37d6bd75717", size = 268835, upload-time = "2025-05-26T15:18:16.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/67/19f33eeb4ffff0e2fd39afd4783a6ee38a6d58bcc1ddade779712a7e2e49/sphobjinv-2.4.tar.gz", hash = "sha256:44d57e7e87e17d8c7b053c853dcc36f80cbf7d1fc152d57634fd7bcae38ca48a", size = 249997, upload-time = "2026-03-23T05:04:54.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/f9/f48a8f489c8ae8930f12c558b4dd26da96791837747fca87e9da2643f12d/sphobjinv-2.3.1.3-py3-none-any.whl", hash = "sha256:41fc39f6f740a707cfe5b24c1a3a4a6e4ddbdd6429a59bf21f0b5ef1fddf932a", size = 50812, upload-time = "2025-05-26T15:18:10.636Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/97/840be4a99531292f8f41069bfcd0654f68296ef4089bfe828607d63ee0ff/sphobjinv-2.4-py3-none-any.whl", hash = "sha256:35f3239e9a6161c20d60146c16645687d06d43e5875d2bda71010c3ee7fd54bc", size = 51315, upload-time = "2026-03-23T05:04:42.434Z" },
 ]
 
 [[package]]
@@ -2483,14 +2486,14 @@ wheels = [
 
 [[package]]
 name = "types-jsonschema"
-version = "4.26.0.20260202"
+version = "4.26.0.20260325"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/07/68f63e715eb327ed2f5292e29e8be99785db0f72c7664d2c63bd4dbdc29d/types_jsonschema-4.26.0.20260202.tar.gz", hash = "sha256:29831baa4308865a9aec547a61797a06fc152b0dac8dddd531e002f32265cb07", size = 16168, upload-time = "2026-02-02T04:11:22.585Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/bf/97b3438f0a3834d7d8e515fbccd4e1ca957465e094f0b260162a5cf9b951/types_jsonschema-4.26.0.20260325.tar.gz", hash = "sha256:84c319ba1af5463394d99accd96db543b7cb0eeab0938c652c18129536672002", size = 16441, upload-time = "2026-03-25T04:08:12.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/06/962d4f364f779d7389cd31a1bb581907b057f52f0ace2c119a8dd8409db6/types_jsonschema-4.26.0.20260202-py3-none-any.whl", hash = "sha256:41c95343abc4de9264e333a55e95dfb4d401e463856d0164eec9cb182e8746da", size = 15914, upload-time = "2026-02-02T04:11:21.61Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ec/65a4a55a024c9eb7fe08c207c0a94a537db0db50fea61ad565fa6b39220f/types_jsonschema-4.26.0.20260325-py3-none-any.whl", hash = "sha256:032a952fd32d9e06b71bdce5a5b4005dd58a074f6cb2899e96b633cbe1c28f40", size = 16080, upload-time = "2026-03-25T04:08:11.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

I think it makes sense to follow the same style everywhere, even in our generated markdown docs. At the same time we don't want to depend on the rumdl binary being installed, so this fixes a few common issue without going too far down the rabbit hole.

Closes #220 

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
