### PR TITLE
fix: 🐛 escape newlines to prevent tables breaking

### DIFF
--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -76,11 +76,11 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
-def _escape_newline(cell: str) -> str:
+def _replace_newlines(cell: str) -> str:
     return cell.replace("\n", " ")
 
 
-def _escape_row(row: list[str]) -> list[str]:
+def _replace_newlines_in_row(row: list[str]) -> list[str]:
     return list(map(_escape_newline, row))
 
 
@@ -108,8 +108,8 @@ def _adjust_column_widths(header_row: list[str], data_rows: list[list[str]]) -> 
     if not header_row:
         return ""
 
-    header_row = _escape_row(header_row)
-    data_rows = list(map(_escape_row, data_rows))
+    header_row = _replace_newlines_in_row(header_row)
+    data_rows = _map(data_rows, _replace_newlines_in_row)
     widths = _column_widths(header_row, data_rows)
 
     return "\n".join(

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -76,6 +76,14 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
     return ", ".join(_map(value, lambda item: f"`{item}`"))
 
 
+def _escape_newline(cell: str) -> str:
+    return cell.replace("\n", " \\n ")
+
+
+def _escape_row(row: list[str]) -> list[str]:
+    return list(map(_escape_newline, row))
+
+
 def _max_column_width(rows: list[list[str]], col: int) -> int:
     return max(map(lambda row: len(row[col]), rows), default=0)
 
@@ -100,6 +108,8 @@ def _adjust_column_widths(header_row: list[str], data_rows: list[list[str]]) -> 
     if not header_row:
         return ""
 
+    header_row = _escape_row(header_row)
+    data_rows = list(map(_escape_row, data_rows))
     widths = _column_widths(header_row, data_rows)
 
     return "\n".join(

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -81,7 +81,7 @@ def _replace_newlines(cell: str) -> str:
 
 
 def _replace_newlines_in_row(row: list[str]) -> list[str]:
-    return list(map(_escape_newline, row))
+    return _map(row, _replace_newlines)
 
 
 def _max_column_width(rows: list[list[str]], col: int) -> int:

--- a/src/seedcase_flower/build_sections.py
+++ b/src/seedcase_flower/build_sections.py
@@ -77,7 +77,7 @@ def _inline_code_list(value: Union[str, list[str]]) -> str:
 
 
 def _escape_newline(cell: str) -> str:
-    return cell.replace("\n", " \\n ")
+    return cell.replace("\n", " ")
 
 
 def _escape_row(row: list[str]) -> list[str]:


### PR DESCRIPTION
# Description

Closes #221 (more details there)

I think we have at least three options to deal with these newlines:

1. Replace with `<br>` in the markdown. This will actually create a newline in the rendered quarto table. **However**, this does not seem to be "the right thing to do" in terms of [our beetle example package](https://github.com/seedcase-project/example-seed-beetle/blob/main/datapackage.json) where the newlines are in seemingly arbitrary locations.
2. Replace with `\n` in the markdown. This will not be rendered by quarto as a newline, just a space. Retaining `\n` rather than replacing with space in the markdown gives the user the option to manually replace these and insert `<br>` tags if they want. **However**, this preserves newlines in the
    <img width="957" height="261" alt="image" src="https://github.com/user-attachments/assets/0e681c6a-db06-4125-a683-a16172e9c342" />
3. Replace with space. This seems to be the most reasonable rendering of the output everywhere, but it gives no ability to actually retain the newlines if so desired.

I went with 3 here, but does anyone have an idea of the purpose of the newlines characters in the example beetle package? Were they included to create actual linebreaks at those seemingly arbitrary positions or are they some artifact? I can see an argument for saying that newlines in datapackage.json is the user's fault but although that is correct, it might be unhelpful for them? I guess they could easily do a search and replace to get rid of them if they don't want them (but as easily they could replace all their newlines with `<br>` if they actually want them to show up...). We could also do some different conversions for view vs build styles, but it might get messy to keep track of differences like that between the styles.

After this PR, tables render as expected:

<img width="770" height="798" alt="image" src="https://github.com/user-attachments/assets/3b3212a7-5748-46ab-99fe-74614e7e60d4" />


Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
