### PR TITLE
feat: ✨ show better error message when the input is not JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ each release.
 
 ### Feat
 
-- ✨ suppress tracebacks from all errors when running from the CLI (#216)
+- ✨ suppress tracebacks from all errors when running from the CLI
+  (#216)
 
 ## 0.18.0 (2026-03-25)
 

--- a/src/seedcase_flower/errors.py
+++ b/src/seedcase_flower/errors.py
@@ -51,3 +51,14 @@ class HTTPDomainError(FlowerError):
             resolved_address,
             "Couldn't connect to the server because the domain wasn't found.",
         )
+
+
+class NotJSONError(FlowerError):
+    """Error when a URL does not return JSON content."""
+
+    def __init__(self, resolved_address: str, content_type: str) -> None:
+        """Initialize NotJSONError with resolved_address and actual content type."""
+        super().__init__(
+            resolved_address,
+            f"Expected JSON but received '{content_type}'.",
+        )

--- a/src/seedcase_flower/read_properties.py
+++ b/src/seedcase_flower/read_properties.py
@@ -17,6 +17,8 @@ from seedcase_flower.errors import (
 )
 from seedcase_flower.parse_source import Address
 
+JSON_CONTENT_TYPES = ("application/json", "application/ld+json", "application/geo+json")
+
 
 def read_properties(address: Address) -> dict[str, Any]:
     """Read properties from a local or remote datapackage."""
@@ -34,8 +36,9 @@ def read_properties(address: Address) -> dict[str, Any]:
         try:
             with request.urlopen(address.value) as open_url:  # nosec B310
                 content_type = open_url.headers.get("Content-Type", "")
-                if not content_type.startswith(("application/json", "text/plain")):
-                    raise NotJSONError(address.value, content_type)
+                if not content_type.startswith(JSON_CONTENT_TYPES + ("text/plain",)):
+                    main_type = content_type.split(";")[0].strip()
+                    raise NotJSONError(address.value, main_type)
                 datapackage = json.load(open_url)
         except HTTPError as e:
             raise HTTP404Error(address.value, e.code, e.reason)

--- a/src/seedcase_flower/read_properties.py
+++ b/src/seedcase_flower/read_properties.py
@@ -13,6 +13,7 @@ from seedcase_flower.errors import (
     HTTP404Error,
     HTTPDomainError,
     JSONFormatError,
+    NotJSONError,
 )
 from seedcase_flower.parse_source import Address
 
@@ -32,6 +33,9 @@ def read_properties(address: Address) -> dict[str, Any]:
     else:
         try:
             with request.urlopen(address.value) as open_url:  # nosec B310
+                content_type = open_url.headers.get("Content-Type", "")
+                if not content_type.startswith(("application/json", "text/plain")):
+                    raise NotJSONError(address.value, content_type)
                 datapackage = json.load(open_url)
         except HTTPError as e:
             raise HTTP404Error(address.value, e.code, e.reason)

--- a/tests/test_read_properties.py
+++ b/tests/test_read_properties.py
@@ -13,6 +13,7 @@ from seedcase_flower.errors import (
     HTTP404Error,
     HTTPDomainError,
     JSONFormatError,
+    NotJSONError,
 )
 from seedcase_flower.parse_source import Address, parse_source
 from seedcase_flower.read_properties import read_properties
@@ -126,4 +127,17 @@ def test_read_properties_raises_on_remote_dns_failure(mocker):
     )
 
     with pytest.raises(HTTPDomainError):
+        read_properties(address)
+
+
+@pytest.mark.usefixtures("mocker")
+def test_read_properties_raises_on_non_json_content_type(mocker):
+    """Remote URL returning non-JSON content type should raise NotJSONError."""
+    mock_urlopen = mocker.patch("seedcase_flower.read_properties.request.urlopen")
+    mock_response = mock_urlopen.return_value.__enter__.return_value
+    mock_response.headers.get.return_value = "text/html; charset=utf-8"
+
+    address = Address(value="https://example.com/datapackage.json", local=False)
+
+    with pytest.raises(NotJSONError, match="Expected JSON but received 'text/html"):
         read_properties(address)


### PR DESCRIPTION
# Description

Before PR:
<img width="859" height="93" alt="image" src="https://github.com/user-attachments/assets/7db8a46a-7f13-4b03-9515-c7b1b8b7aa83" />

After PR:
<img width="861" height="93" alt="image" src="https://github.com/user-attachments/assets/7b54720f-a034-41de-a1c1-a598b7facd57" />

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
