### PR TITLE
refactor: ♻️ split the error message for readability

### DIFF
--- a/src/seedcase_flower/errors.py
+++ b/src/seedcase_flower/errors.py
@@ -6,9 +6,9 @@ class FlowerError(Exception):
 
     def __init__(self, resolved_address: str, reason: str = "") -> None:
         """Initialize FlowerError with resolved_address and optional reason."""
-        message = f"Could not load '{resolved_address}'."
+        message = f"Could not load '{resolved_address}'.\n"
         if reason:
-            message += f" {reason}"
+            message += f"{reason}"
         super().__init__(message)
 
 


### PR DESCRIPTION
# Description

I think this makes it easier to read.

Before:
<img width="1311" height="360" alt="image" src="https://github.com/user-attachments/assets/c6ec31be-9eab-4a06-aff1-a3789c163bdf" />


After:
<img width="1311" height="396" alt="image" src="https://github.com/user-attachments/assets/698d1d87-78c3-43d1-8866-493e399c8fb7" />


Needs a quick review.

## Checklist

- [x] Ran `just run-all`
