### PR TITLE
build: :hammer: there are fake URLs in `tests/` so ignore them

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,8 @@ check-urls:
       --exclude-all-private \
       --exclude "^file://" \
       --exclude "raw\.githubusercontent\.com" \
-      --exclude-path "_badges.qmd"
+      --exclude-path "_badges.qmd" \
+      --exclude-path "tests/*"
 
 # Check the commit messages on the current branch that are not on the main branch
 check-commits:


### PR DESCRIPTION
# Description

There are fake URLs that get checked by lychee and output an error. So this tells lychee to not check files in `tests/`

Needs no review.

## Checklist

- [x] Ran `just run-all`
