### PR TITLE
docs: :pencil2: add missing attribute docs in `Many` docstring

### DIFF
--- a/src/seedcase_flower/sections.py
+++ b/src/seedcase_flower/sections.py
@@ -199,6 +199,8 @@ class Many(KebabModel, frozen=True):
             this template.
         content: The content item to display in this section; choices are `resources`
             and `fields`.
+        template_path: See `Content.template_path` for more details.
+        jinja_variable: See `Content.jinja_variable` for more details.
 
     Examples:
         ```{python}


### PR DESCRIPTION
# Description

This was missing.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
