### PR TITLE
feat: :sparkles:  improve colors used in the CLI help

### DIFF
--- a/src/seedcase_flower/cli.py
+++ b/src/seedcase_flower/cli.py
@@ -43,6 +43,12 @@ _CONSOLE_THEME = Theme(
     }
 )
 
+_HELP_CONSOLE_THEME = Theme(
+    {
+        "markdown.code": "yellow not reverse",
+    }
+)
+
 app = App(
     name="seedcase-flower",
     help="Flower generates human-readable documentation from Data Packages.",
@@ -53,6 +59,7 @@ app = App(
         )
     ),
     default_parameter=Parameter(negative=(), show_default=True),
+    console=Console(theme=_HELP_CONSOLE_THEME),
     config=[
         config.Toml(
             ".flower.toml",

--- a/src/seedcase_flower/internals.py
+++ b/src/seedcase_flower/internals.py
@@ -18,7 +18,7 @@ def _format_param_help(entry: HelpEntry) -> str:
 
 def _add_highlight_syntax(name: str, entry_type: Optional[type]) -> str:
     """Add markup character to highlight in colors, etc where desired."""
-    formatted_name = f"[bold cyan]{name}[/bold cyan]"
+    formatted_name = f"[bold blue]{name}[/bold blue]"
     if not name.startswith("-"):
         # Matching the `dim` used by default in cyclopts for `choices` and
         # `defaults` in the description

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,11 +260,11 @@ def test_build_help_page_applies_rich_markup(capsys):
     with pytest.raises(SystemExit):
         app(["build", "--help"], console=markup_console)
     output = capsys.readouterr().out
-    assert "[bold cyan]--source[/bold cyan]" in output
+    assert "[bold blue]--source[/bold blue]" in output
     assert "[dim]<SOURCE>[/dim]" in output
-    assert "[bold cyan]--style[/bold cyan]" in output
+    assert "[bold blue]--style[/bold blue]" in output
     assert "[dim]<STYLE>[/dim]" in output
-    assert "[bold cyan]--verbose[/bold cyan]" in output
+    assert "[bold blue]--verbose[/bold blue]" in output
     # Boolean flags must not produce a positional placeholder
     assert "[dim]<verbose>[/dim]" not in output
 


### PR DESCRIPTION
# Description

I think the markdown code tags have unfortunate highlighting with the bg color that is difficult to read. This improves that and also changes the colors of the arguments so that they go nicer together with the new color of the markdown code tags. I went with blue and yellow after trying to keep the cyan and combining it with other colors; open to other suggestions.

Before:
<img width="835" height="303" alt="image" src="https://github.com/user-attachments/assets/cdfa0e8a-ae08-4517-95db-e5b3a7901747" />

After:
<img width="835" height="303" alt="image" src="https://github.com/user-attachments/assets/a42da902-56d0-45b0-bc13-c321968aae3a" />


Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
