### PR TITLE
build: :adhesive_bandage: only include subdirectories in examples exclude pattern

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -10,7 +10,7 @@ exclude = [
   # This has it's own structure
   "**/LICENSE.md",
   # Generated example output (subdirectories only)
-  "docs/examples/**"
+  "docs/examples/*/"
 ]
 
 # List style: `-`


### PR DESCRIPTION
# Description

Before, `docs/examples/index.qmd` wasn't included when running `just format-md`. I noticed this when I wanted to format my changes in #269.

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
