### PR TITLE
docs: :memo: correct outdated parts of diagrams

### DIFF
--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -226,13 +226,14 @@ flowchart TD
             section("Section<br>[class]")
         end
 
+        parse_source["parse_source()<br>[function]"]
+        address["address<br>[Address]"]
         read_properties["read_properties()<br>[function]"]
         properties["properties<br>[dict]"]
         build("build()<br>[function]")
         view("view()<br>[function]")
 
-        read_properties --> properties
-        properties --> build & view
+        parse_source --> address --> read_properties --> properties --> build & view
         cfg --> build & view
     end
 
@@ -243,7 +244,7 @@ flowchart TD
         output_screen("Human-readable metadata<br>[terminal output]")
     end
 
-    user --"Provides datapackage.json path<br>programmatically"--> read_properties
+    user --"Provides datapackage.json <br>source string"--> parse_source
     user -."(Optional)<br>Provides configurations,<br>as file or Python class".-> cfg
     user -."(Optional)<br>Provides custom templates<br>in folder".-> templates
     templates --"Defines output<br>structure and layout"--> cfg

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -64,10 +64,10 @@ The internal flow of `build()` is shown in the diagram below.
 %%| label: fig-python-build-flow
 %%| fig-cap: "Diagram of the internal flow of functions and objects in the `build()` CLI function."
 flowchart TD
-    source:::input --> parse_source{{"parse_source()"}} --> path
+    source:::input --> parse_source{{"parse_source()"}} --> Address
     style_cfg[style]:::input --> Config
     template_dir_cfg[template_dir]:::input --> Config
-    path --> read_properties{{"read_properties()"}} --> properties
+    Address --> read_properties{{"read_properties()"}} --> properties
     properties & Config --> build_sections{{"build_sections()"}} --> output["list[BuiltSection]"]
     output --> write_sections{{"write_sections()"}}
     output_dir:::input --> Config
@@ -93,9 +93,9 @@ The internal flow of `view()` is shown in the diagram below.
 %%| label: fig-python-view-flow
 %%| fig-cap: "Diagram of the internal flow of functions and objects in the `view()` CLI function."
 flowchart TD
-    source:::input --> parse_source{{"parse_source()"}} --> path
+    source:::input --> parse_source{{"parse_source()"}} --> address
     style_cfg[style]:::input --> Config
-    path --> read_properties{{"read_properties()"}} --> properties
+    address --> read_properties{{"read_properties()"}} --> properties
     properties & Config --> build_sections{{"build_sections()"}} --> output["list[BuiltSection]"]
     output --> pretty_print{{"pretty_print()"}}
 

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -12,9 +12,9 @@ for details). The design decisions behind these styles are described in
 the [output interface page](/docs/design/interface/outputs.qmd).
 
 ::: callout-note
-Depending on your conversion tool (such as Quarto, Pandoc, or Typst), you can render 
-one-page styles as PDF, HTML, or view them directly in the terminal with the `view` 
-command. Multi-page styles are usually best suited for HTML, but this depends on 
+Depending on your conversion tool (such as Quarto, Pandoc, or Typst), you can render
+one-page styles as PDF, HTML, or view them directly in the terminal with the `view`
+command. Multi-page styles are usually best suited for HTML, but this depends on
 your rendering pipeline.
 :::
 


### PR DESCRIPTION
# Description

Fixes some outdated diagram nodes. More could be done in a follow up PR after a discussion in https://github.com/seedcase-project/guidebook/issues/131

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
