### PR TITLE
docs: 📝 shorten tagline

### DIFF
--- a/_metadata.yml
+++ b/_metadata.yml
@@ -6,4 +6,4 @@ links:
   github: "https://github.com/seedcase-project/seedcase-flower"
   site: "https://flower.seedcase-project.org"
 
-tagline: "Turn your Data Package metadata into human-readable documentation"
+tagline: "Turn metadata into human-readable documentation"


### PR DESCRIPTION
# Description

Ties us less to a specific metadata spec and fits on one line; thoughts?

<img width="1276" height="648" alt="image" src="https://github.com/user-attachments/assets/37f606fd-3316-4179-952b-b60bfb81a2e4" />


Needs a quick review.

## Checklist

- [ ] Ran `just run-all`
