### PR TITLE
chore: :adhesive_bandage: update `just build-examples` to use `seedcase-soil`

### DIFF
--- a/justfile
+++ b/justfile
@@ -133,9 +133,10 @@ build-examples:
     styles() {
       basename src/seedcase_flower/styles/*/ |tr '_' '-' | grep -v '^shared$'
     }
+    flora_json="$(uv run python -c 'from seedcase_soil import Example; print(Example.flora.path)')"
     build_example() {
       local style=$1
-      uv run seedcase-flower build docs/includes/datapackage.json \
+      uv run seedcase-flower build "$flora_json" \
         --style $style \
         --output-dir docs/examples/$style
     }


### PR DESCRIPTION
# Description

Now that the flora json lives in `seedcase-soil`, this recipe needed to be updated.

Thanks for the help with this, @joelostblom 🌷 

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
