### PR TITLE
chore: :adhesive_bandage: remove `build-examples` from `@_builds`

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@
 
 @_tests: test-python
 
-@_builds: build-contributors build-examples build-website build-readme
+@_builds: build-contributors build-website build-readme
 
 # Run all build-related recipes in the justfile
 run-all: install-deps update-quarto-theme format-python format-md _checks _tests _builds


### PR DESCRIPTION
# Description

It's also a part of `build-website`, so currently we're generating the examples twice with `just run-all`.

Needs a quick review.

## Checklist

- [ ] Ran `just run-all`
