### PR TITLE
chore: 🔧 allow use of `Optional[]` type hint

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -13,8 +13,12 @@ extend-select = [
   # Check for unused arguments
   "ARG",
 ]
-# Ignore missing docstring at the top of files
-ignore = ["D100"]
+ignore = [
+  # Ignore missing docstring at the top of files.
+  "D100",
+  # Use `Optional[]` typing.
+  "UP045",
+]
 
 [lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
# Description

After the Ruff update that enables a lot more lints, this is one that we will ignore.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
